### PR TITLE
Rule violation examples

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -731,11 +731,27 @@ A status message is included in every response when you make a new transaction.
 The status message can be used for debugging and may include a more specific
 error message.
 
+Examples:
+
 ````json
 {
-    "status" : {
+    "status": {
         "code": 40000,
         "message": "parameter 'amount' is required"
+    }
+}
+
+{
+    "status": {
+        "code": 40200,
+        "message": "amount > 100 EUR"
+    }
+}
+
+{
+    "status": {
+        "code": 40200,
+        "message": "not (fully 3dsecure or subsequent recurring)"
     }
 }
 ````


### PR DESCRIPTION
Prompted by the following communication in the clearpay channel in QuickPay's Slack:

> kd: ct-clearhaus: ved du om i har noget info omkring jeres "40200: Clearhaus rule violation" hvad den dækker over, kunne ikke lige finde noget på jers docs
> ct-clearhaus: kd: vi svarer den regel tilbage som har udløst fejlkoden.
> ta: @aq_status_code="40200", @aq_status_msg="Clearhaus rule violation"
> ct-clearhaus: Det er ikke den "message" vi returnerer.

@ct-clearhaus @soltveit WDYT?