### PR TITLE
Account descriptor as `descriptor`

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -411,7 +411,7 @@ Example response (snippet):
 {
     "merchant_id": "000000003000001",
     "name": "Merchant Ltd.",
-    "text_on_statement": "merchant.com",
+    "descriptor": "merchant.com",
     "country": "GBR",
     "mcc": "1111"
 }
@@ -676,11 +676,11 @@ https://gateway.clearhaus.com/account
   <dd>[0-9]{15} <br />Used for 3-D Secure and also for reference when talking
   to our support staff. For 3-D Secure it is important to represent this number
   with leading zeros.</dd>
-  <dt>text_on_statement</dt>
+  <dt>descriptor</dt>
   <dd>
-    [\x20-\x7E]{0,22} 
+    [\x20-\x7E]{0,22}
     <i><a target="_blank" href="http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters">ASCII printable characters</a></i> </br>
-    The default text_on_statement.
+    The default <code>text_on_statement</code>.
   </dd>
   <dt>name</dt>
   <dd>


### PR DESCRIPTION
This is for consistency. Actually, `GET /account` is the only place we screwed up and named the account's descriptor `text_on_statement`.

The naming is that the account has a `descriptor` whereas a transaction has a `text_on_statement`. The account's `descriptor` is the default `text_on_statement` for all transactions if nothing is supplied in the `POST` to create the given transaction.