### PR TITLE
Add invalid transaction status code

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -712,6 +712,7 @@ Declined   |  40000 |  General input error
            |  40130 |  Invalid expire date
            |  40135 |  Card expired
            |  40140 |  Invalid currency
+           |  40150 |  Invalid transaction
            |  40200 |  Clearhaus rule violation
            |  40300 |  3-D Secure problem
            |  40310 |  3-D Secure authentication failure

--- a/source/index.md
+++ b/source/index.md
@@ -712,7 +712,7 @@ Declined   |  40000 |  General input error
            |  40130 |  Invalid expire date
            |  40135 |  Card expired
            |  40140 |  Invalid currency
-           |  40150 |  Invalid transaction
+           |  40190 |  Invalid transaction
            |  40200 |  Clearhaus rule violation
            |  40300 |  3-D Secure problem
            |  40310 |  3-D Secure authentication failure


### PR DESCRIPTION
This error code will be used for transactions that are not possible.

For instance a subsequent recurring transaction for a Maestro card where the merchant has not been assigned a static AAV.

A detailed and descriptive `status.message` should be returned explaining the specific issue.