### PR TITLE
Wrap MobilePay Online parameters

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -601,11 +601,11 @@ object][ApplePay-PaymentToken] for more information.
 <dl class="dl-horizontal">
   <dt>mobilepayonline[pan]</dt>
   <dd>[0-9]{12,19} <br /> Primary account number of card to charge.</dd>
-  <dt>mobilepayonline[expire_month]</dt>
+  <dt>mobilepayonline<br />[expire_month]</dt>
   <dd>[0-9]{2} <br /> Expiry month of card to charge.</dd>
-  <dt>mobilepayonline[expire_year]</dt>
+  <dt>mobilepayonline<br />[expire_year]</dt>
   <dd>[0-9]{4} <br /> Expiry year of card to charge.</dd>
-  <dt>mobilepayonline[phone_number]</dt>
+  <dt>mobilepayonline<br />[phone_number]</dt>
   <dd>
     [\x20-\x7E]{1,15} <br />
     <i>Optional</i> <br />


### PR DESCRIPTION
To avoid truncation by the stylesheet.

Before:

![screenshot_2018-07-24_13-19-47](https://user-images.githubusercontent.com/14069221/43136088-e110686c-8f47-11e8-9279-f7ecef370ffc.png)

After:

![screenshot_2018-07-24_13-45-25](https://user-images.githubusercontent.com/14069221/43136092-e4c906e4-8f47-11e8-9948-95733ad2d788.png)

I had no luck editing the stylesheets in `bower_components`.