### PR TITLE
Clarify deprecation of card tokenization

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -262,6 +262,8 @@ Example response (snippet):
 
 ## Tokenize a card
 
+This is now deprecated!
+
 A card token is a value that references card details (see
 [Tokenization][Tokenization]). You can use a card token (card resource) to make
 authorization and credit transactions.


### PR DESCRIPTION
A similar sentence already starts the Cards section (API References -> Resources -> Cards). I have recently witnessed a new partner not noticing the deprecation of card tokenization.

https://github.com/clearhaus/gateway-api-docs/blame/809912875d11ef797b0df9bee91116b0cf5f14c6/source/index.html.md#L802