### PR TITLE
Use pip to install awscli

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - run:
           name: Install AWS CLI
           command: |
-            sudo apt-get install awscli
+            sudo pip install awscli
       - run:
           name: Build Docker image
           command: |


### PR DESCRIPTION
It appears installing `awscli` using `apt-get` has begun to fail consistently on CircleCI's Ubuntu 14.04 hosts.

```
sudo apt-get install awscli

Reading package lists... Done

Building dependency tree

Reading state information... Done

E: Unable to locate package awscli
Exited with code 100
```

This is inspired by https://docs.aws.amazon.com/cli/latest/userguide/install-linux.html#install-linux-awscli