### PR TITLE
Correct and clarify IP address format

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -466,7 +466,7 @@ Exactly one payment method must be used.
   <dt>currency</dt>
   <dd>[A-Z]{3} <br /> <a target="_blank" href="currencies.txt">3-letter currency code</a>. (Some exponents differ from ISO 4217.)</dd>
   <dt>ip</dt>
-  <dd>[0-9\.a-fA-F:]{3,45} <br /> <i>Optional</i> <br /> Cardholder's IP address. It must be a valid v4 or v6 address.</dd>
+  <dd>[0-9.a-fA-F:]{3,45} <br /> <i>Optional</i> <br /> Cardholder's IP address. It must be a valid v4 or v6 address.</dd>
   <dt>recurring</dt>
   <dd>(true|false) <br /> <i>Optional</i> <br /> Must be <code>true</code> for recurring payments.</dd>
   <dt>text_on_statement</dt>

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -466,7 +466,7 @@ Exactly one payment method must be used.
   <dt>currency</dt>
   <dd>[A-Z]{3} <br /> <a target="_blank" href="currencies.txt">3-letter currency code</a>. (Some exponents differ from ISO 4217.)</dd>
   <dt>ip</dt>
-  <dd>[0-9\.a-fA-F:]{3,39} <br /> <i>Optional</i> <br /> Cardholder's IP address. It must be a valid v4 or v6 address.</dd>
+  <dd>[0-9\.a-fA-F:]{3,45} <br /> <i>Optional</i> <br /> Cardholder's IP address. It must be a valid v4 or v6 address.</dd>
   <dt>recurring</dt>
   <dd>(true|false) <br /> <i>Optional</i> <br /> Must be <code>true</code> for recurring payments.</dd>
   <dt>text_on_statement</dt>

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -466,7 +466,7 @@ Exactly one payment method must be used.
   <dt>currency</dt>
   <dd>[A-Z]{3} <br /> <a target="_blank" href="currencies.txt">3-letter currency code</a>. (Some exponents differ from ISO 4217.)</dd>
   <dt>ip</dt>
-  <dd>[0-9\.a-fA-F:]{3,39} <br /> <i>Optional</i> <br /> Cardholder's IP address (v4 or v6).</dd>
+  <dd>[0-9\.a-fA-F:]{3,39} <br /> <i>Optional</i> <br /> Cardholder's IP address. It must be a valid v4 or v6 address.</dd>
   <dt>recurring</dt>
   <dd>(true|false) <br /> <i>Optional</i> <br /> Must be <code>true</code> for recurring payments.</dd>
   <dt>text_on_statement</dt>


### PR DESCRIPTION
Using Ruby's IPAddr we check that an IP address is in fact a valid v4 or v6 address. It is therefore not sufficient to adhere to the regular expression.

A v6 address can be up to 45 characters long. We have this set correctly in the database layer.