### PR TITLE
Introduce credential, initiator and series[]

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -591,11 +591,13 @@ Exactly one payment method must be used.
     cardholder if the cardholder decided the transaction should be created.
     This is regardless of whether stored payment credential is being used.
     <br />
-    For compliance reasons there should be a previous approved transaction
-    marked with <code>storing</code> before <code>initiator</code> may be
-    <code>merchant</code>.
-    For subsequent-in-series authorizations, <code>merchant</code> is assumed;
-    otherwise, <code>cardholder</code> is assumed.
+    For compliance reasons there should be a previous approved transaction (for
+    the cardholder and the merchant) marked with <code>storing</code> before
+    <code>initiator</code> may be <code>merchant</code>.
+
+    For subsequent-in-series authorizations, <code>cardholder</code> is invalid
+    and <code>merchant</code> is assumed; otherwise, <code>cardholder</code> is
+    assumed.
 
     <div class="type">Optional</div>
   </dd>
@@ -617,7 +619,7 @@ Exactly one payment method must be used.
     <br />
     <code>recurring</code>: A series of transactions where the cardholder has
     explicitly agreed that the merchant will repeatedly charge the cardholder at
-    regular, predetermined intervals.
+    regular, predetermined intervals that may not exceed 1 year.
     <br />
     <code>unscheduled</code>: A series of transactions where the cardholder has
     explicitly agreed that the merchant will repeatedly charge the cardholder at

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -682,8 +682,19 @@ Exactly one payment method must be used.
   </dt>
   <dd>
     Deprecated! Please use <code>series</code>.
+    <br />
+    <div class="type">Optional. Cannot be used with <code>series</code> or
+    <code>initiator</code>.</div>
   </dd>
 </dl>
+
+<p class="alert alert-info">
+  <b>Notice:</b> When <code>recurring</code> is used, Clearhaus automatically
+  identify if there was a previous-in-series and together with the level of
+  authentication (CSC, 3-D Secure, etc.) conclude if the payment is a first
+  recurring or a subsequent recurring.
+</p>
+
 
 ##### Method: `card`
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -378,7 +378,7 @@ Example response (snippet):
 This should be followed by a capture.
 
 Subsequent recurring authorizations initiated by the merchant are made
-similarly, however, CSC would not be included, and the previous-in-series is
+similarly, however, CSC is not included, and the previous-in-series is
 referenced, e.g.:
 
 ````shell

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -927,7 +927,7 @@ The Mastercard specific reference to the series contains the following parts.
     Trace ID being the concatenation of values
     Data element 63 subfield 1 (Financial Network Code) (position 1-3),
     Data element 63 subfield 2 (Banknet Reference Number) (position 4-9),
-    Data element 15 (Date, Settlement) (position 10-13), and
+    Data element 15 (Date, Settlement, in MMDD format) (position 10-13), and
     two spaces;
     to be used in Data Element 48, Subfield 63.
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1402,27 +1402,6 @@ category, the name might be necessary for approval.
 
 In the first quarter of 2020 signing of POST requests will become mandatory. We will work together with clients to ensure their requests are compliant before introducing enforcement of the requirement in the transaction gateway.
 
-### Remove deprecated `/cards`, `threed_secure` and `card[number]`
-
-The deprecations announced in 2018 will be executed. Partners must expect
-`/cards` endpoints, the `threed_secure` and the `card[number]` parameters to be
-unavailable at any point in time after 2019-08-20.
-Refer to [the documentation source code
-changes](https://github.com/clearhaus/gateway-api-docs/pull/82/files) for the
-exact documentation change.
-
-### Add merchant blocked by cardholder status
-
-Starting 2019-04-11 a new status code `40420 - Merchant blocked by cardholder`
-is avaliable. Please be advised that appropriate action must be taken to
-adequately handle this status code, see [Merchant blocked by cardholder
-status](#merchant-blocked-by-cardholder-status)
-
-### Add a valid test CSC
-
-Starting 2019-02-22 the CSC 987 has been added as a valid CSC for all PANs when
-testing against `gateway.test.clearhaus.com`.
-
 [JSON-HAL]: https://tools.ietf.org/html/draft-kelly-json-hal-08 "IETF HAL draft"
 [HATEOAS]: http://en.wikipedia.org/wiki/HATEOAS
 [Tokenization]: http://en.wikipedia.org/wiki/Tokenization_(data_security)

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1141,6 +1141,11 @@ POST https://gateway.clearhaus.com/credits
   </dd>
 </dl>
 
+<p class="alert alert-info">
+<b>Notice:</b> Implicitly, <code>initiator</code> is <code>merchant</code> and
+<code>credential</code> is <code>used</code>.
+</p>
+
 ### Account
 
 The account resource holds basic merchant account information. Only `HTTP GET`

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -932,6 +932,33 @@ The Mastercard specific reference to the series contains the following parts.
   </dd>
 
   <dt>
+    series[previous][mastercard][exemption]
+    <span class="type">(<code>mit</code>|<code>recurring</code>)</span>
+  </dt>
+  <dd>
+    The <i>Mastercard exemption</i> to be used for the series. If the
+    previous-in-series is a subsequent-in-series it should be equal to the
+    <i>Mastercard exemption</i> applied for the previous-in-series.
+    <ul>
+      <li><code>mit</code>: A <i>Mastercard exemption</i> (not formally an
+      acquirer exemption for SCA) indicating that the transaction is out of
+      scope for SCA. Relevant for varying-amount series. Refer to the partner
+      guideline for more details.</li>
+      <li><code>recurring</code>: The previous-in-series was acquirer exempted
+      for SCA because it was a subsequent-in-series, fixed-amount series
+      authorization.</li>
+    </ul>
+    Clearhaus will use the same <i>Mastercard exemption</i> for the entire
+    series when later referring to the previous-in-series via
+    <code>series[previous][id]</code>.
+
+    <div class="type">Conditional.
+    Required if <code>series[previous][mastercard]</code> is present.
+    Cannot be present if <code>series[previous][id]</code> or
+    <code>series[previous][visa]</code> is present.</div>
+  </dd>
+
+  <dt>
     series[previous][mastercard][tokenized]
     <span class="type">(true|false)</span>
   </dt>

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -394,8 +394,8 @@ curl -X POST \
   -H "Signature: <signing-api-key> RS256-hex <signature>"
 ````
 
-A first-in-series authorization can also be made using the `applepay` or
-`mobilepayonline` payment methods; subsequent-in-series authorizations, however,
+A first-in-series authorization can also be made using the `applepay`
+payment method; subsequent-in-series authorizations, however,
 must be made using the `card` payment method using the card details of the
 previous-in-series authorization referenced.
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -925,7 +925,10 @@ The Mastercard specific reference to the series contains the following parts.
     two spaces;
     to be used in Data Element 48, Subfield 63.
 
-    <div class="type">Optional. Cannot be present if <code>series[previous][id]</code> or <code>series[previous][visa]</code> is present.</div>
+    <div class="type">Conditional.
+    Required if <code>series[previous][mastercard]</code> is present.
+    Cannot be present if <code>series[previous][id]</code> or
+    <code>series[previous][visa]</code> is present.</div>
   </dd>
 
   <dt>
@@ -935,7 +938,10 @@ The Mastercard specific reference to the series contains the following parts.
   <dd>
     Indicate if the series was initiated with a tokenized payment.
 
-    <div class="type">Conditional. Required if <code>series[previous][mastercard][tid]</code> is present.</div>
+    <div class="type">Conditional.
+    Required if <code>series[previous][mastercard]</code> is present.
+    Cannot be present if <code>series[previous][id]</code> or
+    <code>series[previous][visa]</code> is present.</div>
   </dd>
 </dl>
 
@@ -950,7 +956,9 @@ The Visa specific reference to the series has only one part.
     Transaction ID from Field 62.2 of the first (or previous) in series
     authorization; to be used in Field 125, Usage 2, Dataset ID 03.
 
-    <div class="type">Optional. Cannot be present if <code>series[previous][id]</code> or <code>series[previous][mastercard]</code> is present.</div>
+    <div class="type">Optional.
+    Cannot be present if <code>series[previous][id]</code> or
+    <code>series[previous][mastercard]</code> is present.</div>
   </dd>
 </dl>
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -567,13 +567,13 @@ Exactly one payment method must be used.
   </dt>
   <dd>
     Indicate if the payment credential (e.g. PAN and expiry) will be stored for
-    a later transaction where the payment credential is not provided by the
+    future use where the payment credential is not provided by the
     cardholder but collected from (encrypted) storage.
     <br />
     <code>storing</code>: The payment credential will be stored; may only be
     stored if the authorization is approved.
     <br />
-    <code>using</code>: The payment credential was already stored and are now
+    <code>using</code>: The payment credential has already been stored and is now
     being used.
     <br />
     If <code>initiator</code> is <code>merchant</code> then
@@ -651,8 +651,6 @@ Exactly one payment method must be used.
 
     <div class="type">Conditional. Cannot be present if <code>series[type]</code> is present.</div>
   </dd>
-
-
   <dt>text_on_statement
     <span class="type">[\x20-\x7E]{2,22}
       <a target="_blank" href="http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters">
@@ -904,7 +902,7 @@ Only one 3-D Secure version can be used for a given authorization.
 
 If the previous-in-series authorization was made via this API, you should use
 `series[previous][id]` to reference the previous-in-series authorization.
-Otherwise, you must obtain explicit approval from Clearhaus to use these raw
+Otherwise, you must obtain explicit approval from Clearhaus to use the raw
 scheme values grouped in <code>series[previous][mastercard]</code> and
 <code>series[previous][visa]</code>.
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -937,7 +937,7 @@ The Mastercard specific reference to the series contains the following parts.
     <span class="type">(true|false)</span>
   </dt>
   <dd>
-    Indicate if the series was initiated with a tokenized payment method.
+    Indicate if the series was initiated with a tokenized payment.
 
     <div class="type">Conditional. Required if <code>series[previous][mastercard][tid]</code> is present.</div>
   </dd>

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -919,7 +919,7 @@ The Mastercard specific reference to the series contains the following parts.
 <dl class="dl-vertical">
   <dt>
     series[previous][mastercard][tid]
-    <span class="type">[A-z0-9]{3}[A-z0-9]{6}[0-9]{4}[ ]{2}</span>
+    <span class="type">[A-Za-z0-9]{3}[A-Za-z0-9]{6}[0-9]{4}[ ]{2}</span>
   </dt>
   <dd>
     Trace ID being the concatenation of values

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -743,7 +743,7 @@ Exactly one payment method must be used.
 <p class="alert alert-info">
   <b>Notice:</b> An authorization that includes
   <code>card[3dsecure][v1][pares]</code>, <code>card[3dsecure][v2][rreq]</code>,
-  and/or <code>card[csc]</code> cannot be a subsequent recurring authorization.
+  and/or <code>card[csc]</code> cannot be a subsequent-in-series authorization.
 </p>
 
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -616,6 +616,18 @@ Exactly one payment method must be used.
     <div class="type">Optional<br></div>
   </dd>
 
+  <dt>reference
+    <span class="type">[\x20-\x7E]{1,30}
+      <a target="_blank" href= "http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters">
+        ASCII printable characters
+      </a>
+    </span>
+  </dt>
+  <dd>
+    A reference to an external object, such as an order number.
+    <div class="type">Optional</div>
+  </dd>
+
   <dt>
     series[type]
     <span class="type">(<code>recurring</code>|<code>unscheduled</code>)</span>
@@ -658,6 +670,7 @@ Exactly one payment method must be used.
 
     <div class="type">Conditional. Cannot be present if <code>series[type]</code> is present.</div>
   </dd>
+
   <dt>text_on_statement
     <span class="type">[\x20-\x7E]{2,22}
       <a target="_blank" href="http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters">
@@ -668,18 +681,6 @@ Exactly one payment method must be used.
   <dd>
     Text that will be placed on cardholder's bank statement.
     <div class="type">May not be all digits, all same character, or all sequential characters (e.g. "abc")</div>
-    <div class="type">Optional</div>
-  </dd>
-
-  <dt>reference
-    <span class="type">[\x20-\x7E]{1,30}
-      <a target="_blank" href= "http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters">
-        ASCII printable characters
-      </a>
-    </span>
-  </dt>
-  <dd>
-    A reference to an external object, such as an order number.
     <div class="type">Optional</div>
   </dd>
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1146,7 +1146,7 @@ POST https://gateway.clearhaus.com/credits
 
 <p class="alert alert-info">
 <b>Notice:</b> Implicitly, <code>initiator</code> is <code>merchant</code> and
-<code>credential</code> is <code>used</code>.
+<code>credential_on_file</code> is <code>use</code>.
 </p>
 
 ### Account

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -990,6 +990,14 @@ The Visa specific reference to the series has only one part.
   </dd>
 </dl>
 
+<p class="alert alert-info">
+  <b>Notice:</b> A series migrated to Clearhaus using these scheme references
+  cannot be continued with the now deprecated <code>recurring</code> flag.
+  Instead, the subsequent-in-series following an authorization using scheme
+  references must use <code>series[previous][id]</code> to point to the
+  previous in series.
+</p>
+
 
 ### Captures
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -965,19 +965,6 @@ The Mastercard specific reference to the series contains the following parts.
     Cannot be present if <code>series[previous][id]</code> or
     <code>series[previous][visa]</code> is present.</div>
   </dd>
-
-  <dt>
-    series[previous][mastercard][tokenized]
-    <span class="type">(true|false)</span>
-  </dt>
-  <dd>
-    Indicate if the series was initiated with a tokenized payment.
-
-    <div class="type">Conditional.
-    Required if <code>series[previous][mastercard]</code> is present.
-    Cannot be present if <code>series[previous][id]</code> or
-    <code>series[previous][visa]</code> is present.</div>
-  </dd>
 </dl>
 
 The Visa specific reference to the series has only one part.

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -688,6 +688,11 @@ Exactly one payment method must be used.
   a first-in-in-series or a subsequent-in-series recurring.
 </p>
 
+<p class="alert alert-info">
+  <b>Notice:</b> Since <code>series[type]</code> cannot be supplied together
+  with <code>series[previous]</code>, a series will stay of the same type.
+</p>
+
 
 ##### Method: `card`
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -562,25 +562,25 @@ Exactly one payment method must be used.
     <a target="_blank" href="currencies.txt">3-letter currency code</a>. (Some exponents differ from ISO 4217.)
   </dd>
 
-  <dt>credential
-    <span class="type">(<code>storing</code>|<code>using</code>)</span>
+  <dt>credential_on_file
+    <span class="type">(<code>store</code>|<code>use</code>)</span>
   </dt>
   <dd>
     Indicate if the payment credential (e.g. PAN and expiry) will be stored for
     future use where the payment credential is not provided by the
     cardholder but collected from (encrypted) storage.
     <br />
-    <code>storing</code>: The payment credential will be stored; may only be
+    <code>store</code>: The payment credential will be stored; may only be
     stored if the authorization is approved.
     <br />
-    <code>using</code>: The payment credential has already been stored and is now
+    <code>use</code>: The payment credential has already been stored and is now
     being used.
     <br />
     Default:
     <ul>
-      <li><code>using</code>, if <code>initiator</code> is <code>merchant</code>
-      (<code>storing</code> is invalid),</li>
-      <li><code>storing</code>, if the authorization is first-in-series.</li>
+      <li><code>use</code>, if <code>initiator</code> is <code>merchant</code>
+      (<code>store</code> is invalid),</li>
+      <li><code>store</code>, if the authorization is first-in-series.</li>
     </ul>
 
     <div class="type">Optional</code>

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -993,8 +993,8 @@ The Visa specific reference to the series has only one part.
 <p class="alert alert-info">
   <b>Notice:</b> A series migrated to Clearhaus using these scheme references
   cannot be continued with the now deprecated <code>recurring</code> flag.
-  Instead, the subsequent-in-series following an authorization using scheme
-  references must use <code>series[previous][id]</code> to point to the
+  Instead, the subsequent-in-series following an authorization created using
+  scheme references must use <code>series[previous][id]</code> to point to the
   previous in series.
 </p>
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -690,7 +690,7 @@ Exactly one payment method must be used.
 
 <p class="alert alert-info">
   <b>Notice:</b> Since <code>series[type]</code> cannot be supplied together
-  with <code>series[previous]</code>, a series will stay of the same type.
+  with <code>series[previous]</code>, the type of a series cannot change.
 </p>
 
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -335,9 +335,7 @@ parameter `card[name]`.
 
 ## Series of transactions
 
-A cardholder must explicitly agree when subscribing to something, and will
-thereby give the merchant permission to subsequently withdraw money. Clearhaus
-support two type of subscription billing:
+Clearhaus support two type of subscription billing:
 
 * Recurring: Transactions processed at predetermined, regular intervals not
     exceeding 1 year; e.g. a monthly subscription for a magazine.
@@ -345,8 +343,6 @@ support two type of subscription billing:
     predetermined, regular intervals; e.g. a car sharing subscription billed
     weekly but only for weeks when the service is used.
 
-The amount may vary among transactions in a series, but may not exceed the
-authentication amount of the first-in-series authorization.
 There may be an agreed end of the series.
 
 ### Repeatedly reserve money

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -647,7 +647,7 @@ Exactly one payment method must be used.
     of any subsequent-in-series transaction can not exceed the amount of the
     authentication of the first-in-series authorization.
 
-    <div class="type">Conditional. Cannot be present if <code>series[previous][id]</code> is present.</div>
+    <div class="type">Conditional. Cannot be present if <code>series[previous]</code> is present.</div>
   </dd>
 
   <dt>

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -933,21 +933,29 @@ The Mastercard specific reference to the series contains the following parts.
 
   <dt>
     series[previous][mastercard][exemption]
-    <span class="type">(<code>mit</code>|<code>recurring</code>)</span>
+    <span class="type">(<code>fixed_amount_series</code>|<code>variable_amount_series</code>)</span>
   </dt>
   <dd>
-    The <i>Mastercard exemption</i> to be used for the series. If the
-    previous-in-series is a subsequent-in-series it should be equal to the
-    <i>Mastercard exemption</i> applied for the previous-in-series.
+    The <i>Mastercard exemption</i> to be used for the series indicating if the
+    series is a fixed-amount or a variable-amount series.
     <ul>
-      <li><code>mit</code>: A <i>Mastercard exemption</i> (not formally an
-      acquirer exemption for SCA) indicating that the transaction is out of
-      scope for SCA. Relevant for varying-amount series. Refer to the partner
-      guideline for more details.</li>
-      <li><code>recurring</code>: The previous-in-series was acquirer exempted
-      for SCA because it was a subsequent-in-series, fixed-amount series
-      authorization.</li>
+      <li><code>fixed_amount_series</code>:
+        The series is a fixed-amount series. (MPMI value <code>03</code>.)
+      </li>
+      <li><code>variable_amount_series</code>:
+        The series is a variable-amount series. (MPMI value <code>01</code>.)
+        A <i>Mastercard exemption</i> (not formally an acquirer exemption for
+        SCA) indicating that the transaction is out of scope for SCA.
+      </li>
     </ul>
+    If the previous-in-series is a subsequent-in-series it should be equal to
+    the <i>Mastercard exemption</i> applied for the previous-in-series.
+    The value originates from Mastercard Data element 48, Subelement 22,
+    Subfield 1 named "Multi-Purpose Merchant Indicator (MPMI).
+    The value <code>01</code> indicates variable-amount whereas <code>01</code>
+    indicates fixed-amount.
+
+    <br />
     Clearhaus will use the same <i>Mastercard exemption</i> for the entire
     series when later referring to the previous-in-series via
     <code>series[previous][id]</code>.

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -335,7 +335,7 @@ parameter `card[name]`.
 
 ## Series of transactions
 
-Clearhaus currently support only one type of subscription billing:
+Clearhaus currently supports only one type of subscription billing:
 
 * Recurring: Transactions processed at predetermined, regular intervals not
     exceeding 1 year; e.g. a monthly subscription for a magazine.
@@ -374,8 +374,8 @@ Example response (snippet):
 
 This should be followed by a capture.
 
-Subsequent recurring authorizations initiated by the merchant are made
-similarly, however, CSC is not included, and the previous-in-series is
+Subsequent-in-series recurring authorizations initiated by the merchant are
+made similarly, however, CSC is not included, and the previous-in-series is
 referenced, e.g.:
 
 ````shell
@@ -394,7 +394,7 @@ curl -X POST \
 A first-in-series authorization can also be made using the `applepay`
 payment method; subsequent-in-series authorizations, however,
 must be made using the `card` payment method using the card details of the
-previous-in-series authorization referenced.
+referenced previous-in-series authorization.
 
 Any first-in-series authorization must be made with strong customer
 authentication (SCA) regardless of the authorization amount.
@@ -594,7 +594,7 @@ Exactly one payment method must be used.
     Default:
     <ul>
       <li><code>merchant</code>, if the authorization is
-      subsequent-in-subsequent (<code>cardholder</code> is invalid),</li>
+      subsequent-in-series (<code>cardholder</code> is invalid),</li>
       <li><code>cardholder</code>, otherwise.</li>
     </ul>
 
@@ -626,10 +626,10 @@ Exactly one payment method must be used.
     <span class="type"><code>recurring</code></span>
   </dt>
   <dd>
-    Indicate the type of series.
+    The type of series.
     <br />
     <code>recurring</code>: A series of transactions where the cardholder has
-    explicitly agreed that the merchant will repeatedly charge the cardholder at
+    explicitly agreed that the merchant may repeatedly charge the cardholder at
     regular, predetermined intervals that may not exceed 1 year.
 
     <div class="type">Conditional. Cannot be present if <code>series[previous]</code> is present.</div>
@@ -683,9 +683,9 @@ Exactly one payment method must be used.
 
 <p class="alert alert-info">
   <b>Notice:</b> When <code>recurring</code> is used, Clearhaus automatically
-  identify if there was a previous-in-series and together with the level of
-  authentication (CSC, 3-D Secure, etc.) conclude if the payment is a first
-  recurring or a subsequent recurring.
+  identifies if there was a previous-in-series and if that is the case uses the
+  level of authentication (CSC, 3-D Secure, etc.) to conclude if the payment is
+  a first-in-in-series or a subsequent-in-series recurring.
 </p>
 
 
@@ -904,18 +904,19 @@ Only one 3-D Secure version can be used for a given authorization.
 
 ##### Scheme reference to series
 
-If the previous-in-series authorization was made via this API, you should use
-`series[previous][id]` to reference the previous-in-series authorization.
-Otherwise, you must obtain explicit approval from Clearhaus to use the raw
-scheme values grouped in <code>series[previous][mastercard]</code> and
-<code>series[previous][visa]</code>.
+If the previous-in-series authorization was made via this API, you must use
+`series[previous][id]` to reference it. If it was not made via this API, you 
+must obtain explicit approval from Clearhaus to use the raw scheme values
+grouped in <code>series[previous][mastercard]</code> and
+<code>series[previous][visa]</code>. This is relevant when moving subscriptions
+to Clearhaus from another acquirer.
 
 The Mastercard specific reference to the series contains the following parts.
 
 <dl class="dl-vertical">
   <dt>
     series[previous][mastercard][tid]
-    <span class="type">[A-Za-z0-9]{3}[A-Za-z0-9]{6}[0-9]{4}[ ]{2}</span>
+    <span class="type">[A-Za-z0-9]{3}[A-Za-z0-9]{6}[0-9]{4} {2}</span>
   </dt>
   <dd>
     Trace ID being the concatenation of values
@@ -936,8 +937,8 @@ The Mastercard specific reference to the series contains the following parts.
     <span class="type">(<code>fixed_amount_series</code>|<code>variable_amount_series</code>)</span>
   </dt>
   <dd>
-    The <i>Mastercard exemption</i> to be used for the series indicating if the
-    series is a fixed-amount or a variable-amount series.
+    The <i>Mastercard exemption</i> is used to indicate if the series is 
+    fixed-amount or a variable-amount.
     <ul>
       <li><code>fixed_amount_series</code>:
         The series is a fixed-amount series. (MPMI value <code>03</code>.)
@@ -952,12 +953,12 @@ The Mastercard specific reference to the series contains the following parts.
     the <i>Mastercard exemption</i> applied for the previous-in-series.
     The value originates from Mastercard Data element 48, Subelement 22,
     Subfield 1 named "Multi-Purpose Merchant Indicator (MPMI).
-    The value <code>01</code> indicates variable-amount whereas <code>01</code>
-    indicates fixed-amount.
+    The value <code>01</code> indicates variable amount whereas <code>01</code>
+    indicates fixed amount.
 
     <br />
-    Clearhaus will use the same <i>Mastercard exemption</i> for the entire
-    series when later referring to the previous-in-series via
+    Clearhaus uses the same <i>Mastercard exemption</i> for an entire series
+    when a previous-in-series authorization in the series is referenced via
     <code>series[previous][id]</code>.
 
     <div class="type">Conditional.
@@ -975,7 +976,7 @@ The Visa specific reference to the series has only one part.
     <span class="type">[0-9]{15}</span>
   </dt>
   <dd>
-    Transaction ID from Field 62.2 of the first (or previous) in series
+    Transaction ID from Field 62.2 of the first-in-series or previous-in-series
     authorization; to be used in Field 125, Usage 2, Dataset ID 03.
 
     <div class="type">Optional.

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -335,12 +335,10 @@ parameter `card[name]`.
 
 ## Series of transactions
 
-Clearhaus currently supports only one type of subscription billing:
+Clearhaus currently supports the recurring type of subscription billing.
 
-* Recurring: Transactions processed at predetermined, regular intervals not
-    exceeding 1 year; e.g. a monthly subscription for a magazine.
-
-There may be an agreed end of the series.
+There may be an agreed end of the series. The amount may be varying. See the
+partner guideline for more details.
 
 ### Repeatedly reserve money
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -335,7 +335,7 @@ parameter `card[name]`.
 
 ## Series of transactions
 
-Clearhaus currently supports the recurring type of subscription billing.
+Clearhaus supports the recurring type of subscription billing.
 
 There may be an agreed end of the series. The amount may be varying. See the
 partner guideline for more details.

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -592,7 +592,7 @@ Exactly one payment method must be used.
   <dd>
     The initiator of the authorization. An authorization is initiated by the
     cardholder if the cardholder decided the transaction should be created.
-    This is regardless of whether stored payment credential is being used.
+    This is regardless of whether a stored payment credential is being used.
     <br />
     For compliance reasons there should be a previous approved transaction (for
     the cardholder and the merchant) marked with <code>storing</code> before

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -566,7 +566,7 @@ Exactly one payment method must be used.
     future use where the payment credential is not provided by the
     cardholder but collected from (encrypted) storage.
     <br />
-    <code>store</code>: The payment credential will be stored; may only be
+    <code>store</code>: The payment credential will be stored; it may only be
     stored if the authorization is approved.
     <br />
     <code>use</code>: The payment credential has already been stored and is now

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -576,9 +576,12 @@ Exactly one payment method must be used.
     <code>using</code>: The payment credential has already been stored and is now
     being used.
     <br />
-    If <code>initiator</code> is <code>merchant</code> then
-    <code>storing</code> is invalid and <code>using</code> is assumed.
-    For a first-in-series authorization, <code>storing</code> is assumed.
+    Default:
+    <ul>
+      <li><code>using</code>, if <code>initiator</code> is <code>merchant</code>
+      (<code>storing</code> is invalid),</li>
+      <li><code>storing</code>, if the authorization is first-in-series.</li>
+    </ul>
 
     <div class="type">Optional</code>
   </dd>
@@ -594,10 +597,13 @@ Exactly one payment method must be used.
     For compliance reasons there should be a previous approved transaction (for
     the cardholder and the merchant) marked with <code>storing</code> before
     <code>initiator</code> may be <code>merchant</code>.
-
-    For subsequent-in-series authorizations, <code>cardholder</code> is invalid
-    and <code>merchant</code> is assumed; otherwise, <code>cardholder</code> is
-    assumed.
+    <br />
+    Default:
+    <ul>
+      <li><code>merchant</code>, if the authorization is
+      subsequent-in-subsequent (<code>cardholder</code> is invalid),</li>
+      <li><code>cardholder</code>, otherwise.</li>
+    </ul>
 
     <div class="type">Optional</div>
   </dd>
@@ -638,9 +644,10 @@ Exactly one payment method must be used.
   </dt>
   <dd>
     The Clearhaus authorization ID as a reference to the latest approved
-    authorization in the series. The authorization is processed as a
-    first-in-series if not populated while <code>series[type]</code> is
-    populated.
+    authorization in the series.
+    <br />
+    If omitted and <code>series[type]</code> is populated, then the
+    authorization will be a first-in-series.
     <br />
     Can be used only with payment method <code>card</code>.
     <br />

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -335,20 +335,17 @@ parameter `card[name]`.
 
 ## Series of transactions
 
-Clearhaus support two type of subscription billing:
+Clearhaus currently support only one type of subscription billing:
 
 * Recurring: Transactions processed at predetermined, regular intervals not
     exceeding 1 year; e.g. a monthly subscription for a magazine.
-* UCOF (Unscheduled Credential on File): Transactions that does not occur on
-    predetermined, regular intervals; e.g. a car sharing subscription billed
-    weekly but only for weeks when the service is used.
 
 There may be an agreed end of the series.
 
 ### Repeatedly reserve money
 
-A first-in-series payment is made by making an authorization and marking it as a
-`recurring` or `unscheduled` series. For instance, a first-in-series recurring
+A first-in-series recurring payment is made by making an authorization and
+marking it as a `recurring` series. As an example, a first-in-series recurring
 payment could be made this way:
 
 ````shell
@@ -626,7 +623,7 @@ Exactly one payment method must be used.
 
   <dt>
     series[type]
-    <span class="type">(<code>recurring</code>|<code>unscheduled</code>)</span>
+    <span class="type"><code>recurring</code></span>
   </dt>
   <dd>
     Indicate the type of series.
@@ -634,10 +631,6 @@ Exactly one payment method must be used.
     <code>recurring</code>: A series of transactions where the cardholder has
     explicitly agreed that the merchant will repeatedly charge the cardholder at
     regular, predetermined intervals that may not exceed 1 year.
-    <br />
-    <code>unscheduled</code>: A series of transactions where the cardholder has
-    explicitly agreed that the merchant will repeatedly charge the cardholder at
-    unknown times, e.g. based on cardholder usage.
 
     <div class="type">Conditional. Cannot be present if <code>series[previous]</code> is present.</div>
   </dd>

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1367,6 +1367,16 @@ Follow coming changes on the [source code repository](https://github.com/clearha
 
 Sorted by descending timestamp.
 
+### Update authorization parameters
+
+Replace `recurring` with `series[type]=recurring` and add `series[previous]` as
+a way of pointing to the previous-in-series authorization (either via a
+Clearhaus authorization ID or via raw scheme values).
+
+Add also two optional parameters `credential_on_file` and `initiator` to allow
+for explicitly specifying if credential on file is being stored or used, and if
+the transaction is merchant or cardholder initiated.
+
 ### Support for multiple signatures removed
 
 Support for multiple signatures for request signing will be removed any time after 2020-10-31.

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -344,7 +344,7 @@ There may be an agreed end of the series.
 
 ### Repeatedly reserve money
 
-A first-in-series recurring payment is made by making an authorization and
+A first-in-series recurring payment is created by making an authorization and
 marking it as a `recurring` series. As an example, a first-in-series recurring
 payment could be made this way:
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -642,10 +642,6 @@ Exactly one payment method must be used.
     <code>unscheduled</code>: A series of transactions where the cardholder has
     explicitly agreed that the merchant will repeatedly charge the cardholder at
     unknown times, e.g. based on cardholder usage.
-    <br />
-    Although the amount may vary among transactions in any series, the amount
-    of any subsequent-in-series transaction can not exceed the amount of the
-    authentication of the first-in-series authorization.
 
     <div class="type">Conditional. Cannot be present if <code>series[previous]</code> is present.</div>
   </dd>


### PR DESCRIPTION
* `credential` to indicate if stored credential is being stored or used (or
    irrelevant, by leaving it out)
* `initiator` to indicate what party initiate the authorization
* `series[]` to replace `recurring` but also extend with UCOF and
  Clearhaus-internal and raw transaction reference to the previous-in-series

This PR supersedes:
* https://github.com/clearhaus/gateway-api-docs/pull/78
* https://github.com/clearhaus/gateway-api-docs/pull/79
* https://github.com/clearhaus/gateway-api-docs/pull/81
* https://github.com/clearhaus/gateway-api-docs/pull/83


## To do

* [x] Clean-up other explanations
* [x] Reference partner guideline, and potentially move some text over there