### PR TITLE
Add minimalistic MPO API changes

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -687,7 +687,7 @@ object][ApplePay-PaymentToken] for more information.
   </dt>
   <dd>
     Primary account number of card to charge.<br />
-    If <code>token_callback</code> parameter is included, the <code>pan</code> must be a Token PAN.
+    If <code>payment_token</code> parameter is included, the <code>pan</code> must be a Token PAN.
   </dd>
   <dt>mobilepayonline[expire_month]
     <span class="type">[0-9]{2}</span>
@@ -701,7 +701,7 @@ object][ApplePay-PaymentToken] for more information.
   <dd>
     Expiry year of card to charge.
   </dd>
-  <dt>mobilepayonline[token_callback]
+  <dt>mobilepayonline[payment_token]
     <span class="type">[:json:]</span>
   </dt>
   <dd>

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -706,7 +706,7 @@ object][ApplePay-PaymentToken] for more information.
   </dt>
   <dd>
     Full tokenCallback response serialized as JSON, supplied as a string.
-    Required on token based authentication.
+    Required for token-based authentication.
     <br>
     Example: <code>{"paymentId":"string","tokenData":{"cryptogramInfo":{...},...},...}</code>
     <div class="type">Optional</div>

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -686,7 +686,8 @@ object][ApplePay-PaymentToken] for more information.
     <span class="type">[0-9]{12,19}</span>
   </dt>
   <dd>
-    Primary account number of card to charge.
+    Primary account number of card to charge.<br />
+    If <code>cryptogram</code> parameter is included, the <code>pan</code> must be a Token PAN.
   </dd>
   <dt>mobilepayonline[expire_month]
     <span class="type">[0-9]{2}</span>
@@ -699,6 +700,23 @@ object][ApplePay-PaymentToken] for more information.
   </dt>
   <dd>
     Expiry year of card to charge.
+  </dd>
+    <dt>mobilepayonline[cryptogram]
+    <span class="type">[:base64:]{19,21}</span>
+  </dt>
+  <dd>
+    Cryptogram extracted from from MobilePay Online Token Data. Required on
+    token based authentication
+    <div class="type">Optional</div>
+  </dd>
+  </dd>
+    <dt>mobilepayonline[eci]
+    <span class="type">[0-9]{2}</span>
+  </dt>
+  <dd>
+    Eci (Electronic Commerce Indicator) extracted from MobilePay Online Token
+    Data. Only allowed on token based authentication.
+    <div class="type">Optional</div>
   </dd>
   <dt>mobilepayonline[phone_number]
     <span class="type">[\x20-\x7E]{1,15}</span>

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -687,7 +687,7 @@ object][ApplePay-PaymentToken] for more information.
   </dt>
   <dd>
     Primary account number of card to charge.<br />
-    If <code>cryptogram</code> parameter is included, the <code>pan</code> must be a Token PAN.
+    If <code>token_callback</code> parameter is included, the <code>pan</code> must be a Token PAN.
   </dd>
   <dt>mobilepayonline[expire_month]
     <span class="type">[0-9]{2}</span>
@@ -701,21 +701,14 @@ object][ApplePay-PaymentToken] for more information.
   <dd>
     Expiry year of card to charge.
   </dd>
-    <dt>mobilepayonline[cryptogram]
-    <span class="type">[:base64:]{19,21}</span>
+  <dt>mobilepayonline[token_callback]
+    <span class="type">[:json:]</span>
   </dt>
   <dd>
-    Cryptogram extracted from from MobilePay Online Token Data. Required on
-    token based authentication
-    <div class="type">Optional</div>
-  </dd>
-  </dd>
-    <dt>mobilepayonline[eci]
-    <span class="type">[0-9]{2}</span>
-  </dt>
-  <dd>
-    Eci (Electronic Commerce Indicator) extracted from MobilePay Online Token
-    Data. Only allowed on token based authentication.
+    Full tokenCallback response serialized as JSON, supplied as a string.
+    Required on token based authentication.
+    <br>
+    Example: <code>{"paymentId":"string","tokenData":{"cryptogramInfo":{...},...},...}</code>
     <div class="type">Optional</div>
   </dd>
   <dt>mobilepayonline[phone_number]


### PR DESCRIPTION
Adding `cryptogram` and `eci` as optional parameters. Retaining MPO's ability to use non-token based PAN and 3DS.
This ensures backwards compatibility, MPO 3DSecure Fallback and Mastercard support.

For a more full fleshed integration we can opt for receiving the entire `tokenCallback` object from VTS. According to MPO docs, this is what the PSP's are expected to receive from VTS https://github.com/MobilePayDev/MobilePay-Online/pull/25/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R97-R134

This will have to be extended once we figure out what MPO plans to do with Mastercard.

This PR should be read en conjunction with 
* https://github.com/clearhaus/klovedal/pull/480
* https://github.com/clearhaus/authorizer/pull/173