### PR TITLE
Clarify subsequent in series on same card

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -403,8 +403,8 @@ curl -X POST \
 A first-in-series authorization can also be made using the `applepay`,
 `googlepay` or `mobilepayoneline` payment methods.
 
-A subsequent-in-series authorizations must be made using the `card` payment
-method using the card details of the referenced previous-in-series
+A subsequent-in-series authorization must be made using the `card` payment
+method with the exact card details of the referenced previous-in-series
 authorization.
 
 Any first-in-series authorization must be made with strong customer

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -401,9 +401,11 @@ curl -X POST \
 ````
 
 A first-in-series authorization can also be made using the `applepay`,
-`googlepay` or `mobilepayoneline` payment methods; subsequent-in-series
-authorizations, however, must be made using the `card` payment method using the
-card details of the referenced previous-in-series authorization.
+`googlepay` or `mobilepayoneline` payment methods.
+
+A subsequent-in-series authorizations must be made using the `card` payment
+method using the card details of the referenced previous-in-series
+authorization.
 
 Any first-in-series authorization must be made with strong customer
 authentication (SCA) regardless of the authorization amount (when the cardholder


### PR DESCRIPTION
No matter if the first-in-series was made with `applepay`, `googlepay`, or `mobilepayonline`.

Courtesy of @jgivoni.