### PR TITLE
Bump puma to 4.3.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,7 @@ GEM
       activesupport (>= 3.1)
     parallel (1.19.1)
     public_suffix (4.0.4)
-    puma (4.3.3)
+    puma (4.3.8)
       nio4r (~> 2.0)
     rack (2.2.2)
     rack-livereload (0.3.17)


### PR DESCRIPTION
For https://github.com/clearhaus/issues-pci/issues/2832, https://www.debian.org/security/2022/dsa-5146.

Fixes

- https://security-tracker.debian.org/tracker/CVE-2021-41136
- https://security-tracker.debian.org/tracker/CVE-2022-23634
- https://security-tracker.debian.org/tracker/CVE-2022-24790
