### PR TITLE
Explain default behaviour for test pans

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1660,7 +1660,8 @@ one of the special test PANs 2221000000000009, 4111111111111111,
 
 For PANs starting with 420000 and ending with 0000, and PANs starting with
 555555 and ending with 4444, you can specify a valid status `code` as
-transaction amount to trigger the status.
+transaction amount to trigger the status; any other transaction amount will
+result in 40110.
 
 When testing towards the test endpoint, the CSC 987&mdash;and only 987&mdash;is
 considered a match for all PANs.


### PR DESCRIPTION
... when the transaction amount (which is used to trigger specific status codes) is not a valid status code.

