### PR TITLE
Make token one payment method

### DIFF
--- a/website/content/gateway/api_reference/changes/changes.md
+++ b/website/content/gateway/api_reference/changes/changes.md
@@ -17,8 +17,8 @@ which will effectively stop working with schemes mid-October; 2022-10-18 for
 Mastercard and 2022-10-14 for Visa. The `[3dsecure][v1]` authentication method
 and the `[pares]` parameters will be removed any time after 2022-10-18.
 
-#### Payment methods for token frameworks
-The payment methods `token[m4m]` and `token[vts]` have been added on 2022-10-07.
+#### Payment method for token frameworks
+The payment method `token` has been added on 2022-10-07.
 Please see [Method: token](#method-token) for an introduction.
 
 #### Change SLL currency to SLE

--- a/website/content/gateway/api_reference/resources/authorizations/authorizations_methods/token.md
+++ b/website/content/gateway/api_reference/resources/authorizations/authorizations_methods/token.md
@@ -14,7 +14,7 @@ Two token frameworks are supported:
 Requirement of some parameters depends on the initiator of the transaction; a parameter might be required for cardholder-initiated transactions (CITs) and otherwise optional. See the details for each parameter.
 
 {{% notice %}}
-**Notice**: Signing is required to use the `token` payment methods.
+**Notice**: Signing is required to use the `token` payment method.
 {{% /notice %}}
 
 #### Method: token[m4m]


### PR DESCRIPTION
We do not consider `token[m4m]` and `token[vts]` to be two different payment methods. M4M and VTS are token frameworks living under the `token` payment method.

Feel free to merge.