### PR TITLE
Add optional token[m4m][rcai] parameter

### DIFF
--- a/website/content/gateway/api_reference/resources/authorizations/authorizations_methods/token.md
+++ b/website/content/gateway/api_reference/resources/authorizations/authorizations_methods/token.md
@@ -56,6 +56,15 @@ Found in `encryptedPayload.encryptedData.de48se43Data` (MDES) or `encryptedPaylo
 {{% regex_optional %}}Required for CITs; otherwise optional.{{% /regex_optional %}}
 {{% /description_details %}}
 
+{{% description_term %}}token[m4m][rcai] {{% regex %}}[:base64:]{1..150}{{% /regex %}}{{% /description_term %}}
+{{% description_details %}}Remote Commerce Acceptor Identifier.
+
+Merchant identifier such as business website URL or reverse domain name (e.g. com.example.www). The identifier must be encoded as Base64.
+
+Found in `customOutputData.remoteCommerceAcceptorIdentifier` (SCOF). (Not available in MDES.)
+{{% regex_optional %}}Optional.{{% /regex_optional %}}
+{{% /description_details %}}
+
 {{% description_term %}}token[m4m][3dsecure][v2] {{% regex %}}dictionary{{% /regex %}}{{% /description_term %}}
 {{% description_details %}}See [Authentication: [3dsecure][v2]](#authentication-3dsecure-v2).
 {{% regex_optional %}}Optional{{% /regex_optional %}}


### PR DESCRIPTION
Remote Commerce Acceptor Identifier. At present only relevant for Mastercard, i.e. only for `token[m4m]`, not for `token[vts]`.

Rendered:

![Screenshot from 2022-11-08 20-58-36](https://user-images.githubusercontent.com/14069221/200663127-0b3d1945-2ee4-49ab-a5d4-e363b1849011.png)

The two examples for the identifier are borrowed from Mastercard's Customer Interface Specification (DE104SE003).

I found the parameter for SCOF here:
https://developer.mastercard.com/secure-card-on-file/documentation/new-api-reference/apis/#checkout

I have established that the parameter is not present for MDES here:
https://developer.mastercard.com/mdes-digital-enablement/documentation/api-reference/

Mastercard writes that the parameter is "expected to be present in remote commerce transactions initiated via wallets or remote commerce programs that support DSRP cryptogram format 3". I have simplified this to "optional" as we do not dive into such processing details in our API documentation.