### PR TITLE
Add Debit and Debit Refund to transaction status codes table

### DIFF
--- a/website/content/gateway/api_reference/transaction_status/transaction_status_codes_table.md
+++ b/website/content/gateway/api_reference/transaction_status/transaction_status_codes_table.md
@@ -4,27 +4,27 @@ date: 2022-04-13T12:37:22+02:00
 anchor: "transaction-status-codes-table"
 weight: 195
 ---
-| Status   | code  | Meaning                            | Auth | Capture | Refund | Void | Credit |
-| -------- | ----- | ---------------------------------- | ---- | ------- | ------ | ---- | ------ |
-| Approved | 20000 | Approved                           | ✓    | ✓       | ✓      | ✓    | ✓      |
-| Declined | 40000 | General input error                | ✓    | ✓       | ✓      | ✓    | ✓      |
-|          | 40110 | Invalid card number                | ✓    |         |        |      | ✓      |
-|          | 40111 | Unsupported card scheme            | ✓    |         |        |      | ✓      |
-|          | 40120 | Invalid CSC                        | ✓    |         |        |      |        |
-|          | 40130 | Invalid expire date                | ✓    |         |        |      | ✓      |
-|          | 40135 | Card expired                       | ✓    |         |        |      | ✓      |
-|          | 40140 | Invalid currency                   | ✓    |         |        |      | ✓      |
-|          | 40150 | Invalid text on statement          | ✓    | ✓       | ✓      |      | ✓      |
-|          | 40200 | Clearhaus rule violation           | ✓    | ✓       | ✓      | ✓    | ✓      |
-|          | 40300 | 3-D Secure problem                 | ✓    |         |        |      |        |
-|          | 40310 | 3-D Secure authentication failure  | ✓    |         |        |      |        |
-|          | 40400 | Backend problem                    | ✓    |         |        | ✓    | ✓      |
-|          | 40410 | Declined by issuer or card scheme  | ✓    |         |        | ✓    | ✓      |
-|          | 40411 | Card restricted                    | ✓    |         |        |      | ✓      |
-|          | 40412 | Card lost or stolen                | ✓    |         |        |      | ✓      |
-|          | 40413 | Insufficient funds                 | ✓    |         |        |      | ✓      |
-|          | 40414 | Suspected fraud                    | ✓    |         |        |      | ✓      |
-|          | 40415 | Amount limit exceeded              | ✓    |         |        |      | ✓      |
-|          | 40416 | Additional authentication required | ✓    |         |        |      | ✓      |
-|          | 40420 | Merchant blocked by cardholder     | ✓    |         |        |      | ✓      |
-|          | 50000 | Clearhaus error                    | ✓    | ✓       | ✓      | ✓    | ✓      |
+| Status   | code  | Meaning                            | Auth | Capture | Refund | Void | Credit | Debit  | Debit Refund |
+|----------|-------|------------------------------------|------|---------|--------|------|--------|--------|--------------|
+| Approved | 20000 | Approved                           | ✓    | ✓       | ✓      | ✓    | ✓      | ✓      | ✓            |
+| Declined | 40000 | General input error                | ✓    | ✓       | ✓      | ✓    | ✓      | ✓      | ✓            |
+|          | 40110 | Invalid card number                | ✓    |         |        |      | ✓      | ✓      |              |
+|          | 40111 | Unsupported card scheme            | ✓    |         |        |      | ✓      | ✓      |              |
+|          | 40120 | Invalid CSC                        | ✓    |         |        |      |        | ✓      |              |
+|          | 40130 | Invalid expire date                | ✓    |         |        |      | ✓      | ✓      |              |
+|          | 40135 | Card expired                       | ✓    |         |        |      | ✓      | ✓      |              |
+|          | 40140 | Invalid currency                   | ✓    |         |        |      | ✓      | ✓      | ✓            |
+|          | 40150 | Invalid text on statement          | ✓    | ✓       | ✓      |      | ✓      | ✓      |              |
+|          | 40200 | Clearhaus rule violation           | ✓    | ✓       | ✓      | ✓    | ✓      | ✓      |              |
+|          | 40300 | 3-D Secure problem                 | ✓    |         |        |      |        | ✓      |              |
+|          | 40310 | 3-D Secure authentication failure  | ✓    |         |        |      |        | ✓      |              |
+|          | 40400 | Backend problem                    | ✓    |         |        | ✓    | ✓      | ✓      | ✓            |
+|          | 40410 | Declined by issuer or card scheme  | ✓    |         |        | ✓    | ✓      | ✓      | ✓            |
+|          | 40411 | Card restricted                    | ✓    |         |        |      | ✓      | ✓      | ✓            |
+|          | 40412 | Card lost or stolen                | ✓    |         |        |      | ✓      | ✓      | ✓            |
+|          | 40413 | Insufficient funds                 | ✓    |         |        |      | ✓      | ✓      | ✓            |
+|          | 40414 | Suspected fraud                    | ✓    |         |        |      | ✓      | ✓      | ✓            |
+|          | 40415 | Amount limit exceeded              | ✓    |         |        |      | ✓      | ✓      | ✓            |
+|          | 40416 | Additional authentication required | ✓    |         |        |      | ✓      | ✓      | ✓            |
+|          | 40420 | Merchant blocked by cardholder     | ✓    |         |        |      | ✓      |        |              |
+|          | 50000 | Clearhaus error                    | ✓    | ✓       | ✓      | ✓    | ✓      | ✓      | ✓            |

--- a/website/content/gateway/api_reference/transaction_status/transaction_status_codes_table.md
+++ b/website/content/gateway/api_reference/transaction_status/transaction_status_codes_table.md
@@ -10,7 +10,7 @@ weight: 195
 | 40000 | General input error                | ✓    | ✓       | ✓      | ✓    | ✓      | ✓      | ✓            |
 | 40110 | Invalid card number                | ✓    |         |        |      | ✓      | ✓      | ✓            |
 | 40111 | Unsupported card scheme            | ✓    |         |        |      | ✓      | ✓      |              |
-| 40120 | Invalid CSC                        | ✓    |         |        |      |        | ✓      | ✓            |
+| 40120 | Invalid CSC                        | ✓    |         |        |      |        | ✓      |              |
 | 40130 | Invalid expire date                | ✓    |         |        |      | ✓      | ✓      |              |
 | 40135 | Card expired                       | ✓    |         |        |      | ✓      | ✓      | ✓            |
 | 40140 | Invalid currency                   | ✓    | ✓       | ✓      | ✓    | ✓      | ✓      | ✓            |

--- a/website/content/gateway/api_reference/transaction_status/transaction_status_codes_table.md
+++ b/website/content/gateway/api_reference/transaction_status/transaction_status_codes_table.md
@@ -10,7 +10,7 @@ weight: 195
 | 40000 | General input error                | ✓    | ✓       | ✓      | ✓    | ✓      | ✓      | ✓            |
 | 40110 | Invalid card number                | ✓    |         |        |      | ✓      | ✓      | ✓            |
 | 40111 | Unsupported card scheme            | ✓    |         |        |      | ✓      | ✓      |              |
-| 40120 | Invalid CSC                        | ✓    |         |        |      |        | ✓      |              |
+| 40120 | Invalid CSC                        | ✓    |         |        |      |        | ✓      | ✓            |
 | 40130 | Invalid expire date                | ✓    |         |        |      | ✓      | ✓      |              |
 | 40135 | Card expired                       | ✓    |         |        |      | ✓      | ✓      | ✓            |
 | 40140 | Invalid currency                   | ✓    | ✓       | ✓      | ✓    | ✓      | ✓      | ✓            |

--- a/website/content/gateway/api_reference/transaction_status/transaction_status_codes_table.md
+++ b/website/content/gateway/api_reference/transaction_status/transaction_status_codes_table.md
@@ -26,7 +26,7 @@ weight: 195
 | 40414 | Suspected fraud                    | ✓    |         |        |      | ✓      | ✓      | ✓            |
 | 40415 | Amount limit exceeded              | ✓    |         |        |      | ✓      | ✓      | ✓            |
 | 40416 | Additional authentication required | ✓    |         |        |      | ✓      | ✓      | ✓            |
-| 40420 | Merchant blocked by cardholder     | ✓    |         |        |      | ✓      |        |              |
+| 40420 | Merchant blocked by cardholder     | ✓    |         |        |      | ✓      | ✓      | ✓            |
 | 50000 | Clearhaus error                    | ✓    | ✓       | ✓      | ✓    | ✓      | ✓      | ✓            |
 
 Status code `20000` is the only code for which the transaction is approved. For the other codes the transaction is declined.

--- a/website/content/gateway/api_reference/transaction_status/transaction_status_codes_table.md
+++ b/website/content/gateway/api_reference/transaction_status/transaction_status_codes_table.md
@@ -4,27 +4,29 @@ date: 2022-04-13T12:37:22+02:00
 anchor: "transaction-status-codes-table"
 weight: 195
 ---
-| Status   | Code  | Meaning                            | Auth | Capture | Refund | Void | Credit | Debit  | Debit Refund |
-|----------|-------|------------------------------------|------|---------|--------|------|--------|--------|--------------|
-| Approved | 20000 | Approved                           | ✓    | ✓       | ✓      | ✓    | ✓      | ✓      | ✓            |
-| Declined | 40000 | General input error                | ✓    | ✓       | ✓      | ✓    | ✓      | ✓      | ✓            |
-|          | 40110 | Invalid card number                | ✓    |         |        |      | ✓      | ✓      | ✓            |
-|          | 40111 | Unsupported card scheme            | ✓    |         |        |      | ✓      | ✓      |              |
-|          | 40120 | Invalid CSC                        | ✓    |         |        |      |        | ✓      | ✓            |
-|          | 40130 | Invalid expire date                | ✓    |         |        |      | ✓      | ✓      |              |
-|          | 40135 | Card expired                       | ✓    |         |        |      | ✓      | ✓      | ✓            |
-|          | 40140 | Invalid currency                   | ✓    | ✓       | ✓      | ✓    | ✓      | ✓      | ✓            |
-|          | 40150 | Invalid text on statement          | ✓    | ✓       | ✓      |      | ✓      | ✓      |              |
-|          | 40200 | Clearhaus rule violation           | ✓    | ✓       | ✓      | ✓    | ✓      | ✓      | ✓            |
-|          | 40300 | 3-D Secure problem                 | ✓    |         |        |      |        | ✓      |              |
-|          | 40310 | 3-D Secure authentication failure  | ✓    |         |        |      |        | ✓      |              |
-|          | 40400 | Backend problem                    | ✓    |         |        | ✓    | ✓      | ✓      | ✓            |
-|          | 40410 | Declined by issuer or card scheme  | ✓    |         |        | ✓    | ✓      | ✓      | ✓            |
-|          | 40411 | Card restricted                    | ✓    |         |        |      | ✓      | ✓      | ✓            |
-|          | 40412 | Card lost or stolen                | ✓    |         |        |      | ✓      | ✓      | ✓            |
-|          | 40413 | Insufficient funds                 | ✓    |         |        |      | ✓      | ✓      | ✓            |
-|          | 40414 | Suspected fraud                    | ✓    |         |        |      | ✓      | ✓      | ✓            |
-|          | 40415 | Amount limit exceeded              | ✓    |         |        |      | ✓      | ✓      | ✓            |
-|          | 40416 | Additional authentication required | ✓    |         |        |      | ✓      | ✓      | ✓            |
-|          | 40420 | Merchant blocked by cardholder     | ✓    |         |        |      | ✓      |        |              |
-|          | 50000 | Clearhaus error                    | ✓    | ✓       | ✓      | ✓    | ✓      | ✓      | ✓            |
+| Code  | Meaning                            | Auth | Capture | Refund | Void | Credit | Debit  | Debit Refund |
+|-------|------------------------------------|------|---------|--------|------|--------|--------|--------------|
+| 20000 | Approved                           | ✓    | ✓       | ✓      | ✓    | ✓      | ✓      | ✓            |
+| 40000 | General input error                | ✓    | ✓       | ✓      | ✓    | ✓      | ✓      | ✓            |
+| 40110 | Invalid card number                | ✓    |         |        |      | ✓      | ✓      | ✓            |
+| 40111 | Unsupported card scheme            | ✓    |         |        |      | ✓      | ✓      |              |
+| 40120 | Invalid CSC                        | ✓    |         |        |      |        | ✓      | ✓            |
+| 40130 | Invalid expire date                | ✓    |         |        |      | ✓      | ✓      |              |
+| 40135 | Card expired                       | ✓    |         |        |      | ✓      | ✓      | ✓            |
+| 40140 | Invalid currency                   | ✓    | ✓       | ✓      | ✓    | ✓      | ✓      | ✓            |
+| 40150 | Invalid text on statement          | ✓    | ✓       | ✓      |      | ✓      | ✓      |              |
+| 40200 | Clearhaus rule violation           | ✓    | ✓       | ✓      | ✓    | ✓      | ✓      | ✓            |
+| 40300 | 3-D Secure problem                 | ✓    |         |        |      |        | ✓      |              |
+| 40310 | 3-D Secure authentication failure  | ✓    |         |        |      |        | ✓      |              |
+| 40400 | Backend problem                    | ✓    |         |        | ✓    | ✓      | ✓      | ✓            |
+| 40410 | Declined by issuer or card scheme  | ✓    |         |        | ✓    | ✓      | ✓      | ✓            |
+| 40411 | Card restricted                    | ✓    |         |        |      | ✓      | ✓      | ✓            |
+| 40412 | Card lost or stolen                | ✓    |         |        |      | ✓      | ✓      | ✓            |
+| 40413 | Insufficient funds                 | ✓    |         |        |      | ✓      | ✓      | ✓            |
+| 40414 | Suspected fraud                    | ✓    |         |        |      | ✓      | ✓      | ✓            |
+| 40415 | Amount limit exceeded              | ✓    |         |        |      | ✓      | ✓      | ✓            |
+| 40416 | Additional authentication required | ✓    |         |        |      | ✓      | ✓      | ✓            |
+| 40420 | Merchant blocked by cardholder     | ✓    |         |        |      | ✓      |        |              |
+| 50000 | Clearhaus error                    | ✓    | ✓       | ✓      | ✓    | ✓      | ✓      | ✓            |
+
+Status code `20000` is the only code for which the transaction is approved. For the other codes the transaction is declined.

--- a/website/content/gateway/api_reference/transaction_status/transaction_status_codes_table.md
+++ b/website/content/gateway/api_reference/transaction_status/transaction_status_codes_table.md
@@ -4,18 +4,18 @@ date: 2022-04-13T12:37:22+02:00
 anchor: "transaction-status-codes-table"
 weight: 195
 ---
-| Status   | code  | Meaning                            | Auth | Capture | Refund | Void | Credit | Debit  | Debit Refund |
+| Status   | Code  | Meaning                            | Auth | Capture | Refund | Void | Credit | Debit  | Debit Refund |
 |----------|-------|------------------------------------|------|---------|--------|------|--------|--------|--------------|
 | Approved | 20000 | Approved                           | ✓    | ✓       | ✓      | ✓    | ✓      | ✓      | ✓            |
 | Declined | 40000 | General input error                | ✓    | ✓       | ✓      | ✓    | ✓      | ✓      | ✓            |
-|          | 40110 | Invalid card number                | ✓    |         |        |      | ✓      | ✓      |              |
+|          | 40110 | Invalid card number                | ✓    |         |        |      | ✓      | ✓      | ✓            |
 |          | 40111 | Unsupported card scheme            | ✓    |         |        |      | ✓      | ✓      |              |
-|          | 40120 | Invalid CSC                        | ✓    |         |        |      |        | ✓      |              |
+|          | 40120 | Invalid CSC                        | ✓    |         |        |      |        | ✓      | ✓            |
 |          | 40130 | Invalid expire date                | ✓    |         |        |      | ✓      | ✓      |              |
-|          | 40135 | Card expired                       | ✓    |         |        |      | ✓      | ✓      |              |
-|          | 40140 | Invalid currency                   | ✓    |         |        |      | ✓      | ✓      | ✓            |
+|          | 40135 | Card expired                       | ✓    |         |        |      | ✓      | ✓      | ✓            |
+|          | 40140 | Invalid currency                   | ✓    | ✓       | ✓      | ✓    | ✓      | ✓      | ✓            |
 |          | 40150 | Invalid text on statement          | ✓    | ✓       | ✓      |      | ✓      | ✓      |              |
-|          | 40200 | Clearhaus rule violation           | ✓    | ✓       | ✓      | ✓    | ✓      | ✓      |              |
+|          | 40200 | Clearhaus rule violation           | ✓    | ✓       | ✓      | ✓    | ✓      | ✓      | ✓            |
 |          | 40300 | 3-D Secure problem                 | ✓    |         |        |      |        | ✓      |              |
 |          | 40310 | 3-D Secure authentication failure  | ✓    |         |        |      |        | ✓      |              |
 |          | 40400 | Backend problem                    | ✓    |         |        | ✓    | ✓      | ✓      | ✓            |


### PR DESCRIPTION
Fixes https://github.com/clearhaus/issues-pci/issues/3509.

I've went through klovedal `factory.rb` and `visa-direct.rb` to conduct which status codes are reachable.

![image](https://user-images.githubusercontent.com/3591989/234827612-b00abe47-055f-4a37-b555-72fa89faf310.png)

I'm a bit pulsed about the `Invalid currency` as I suppose that the currency is inherited from the original debit.