### PR TITLE
Make name on card mandatory for POW for mastercard

### DIFF
--- a/website/content/gateway/api_reference/resources/credits/credits.md
+++ b/website/content/gateway/api_reference/resources/credits/credits.md
@@ -51,7 +51,7 @@ POST https://gateway.clearhaus.com/credits
 
 {{% description_term %}}card[name] {{% regex %}}[A-Za-z0-9 ]{1,30}{{% /regex %}}{{% /description_term %}}
 {{% description_details %}}Name on card. 
-{{% regex_optional %}}Optional{{% /regex_optional %}}
+{{% regex_optional %}}Required for Mastercard Payment of winnings, otherwise optional{{% /regex_optional %}}
 {{% /description_details %}}
 
 {{% /description_list %}}

--- a/website/content/gateway/examples/payout_to_cardholder/payout_to_cardholder.md
+++ b/website/content/gateway/examples/payout_to_cardholder/payout_to_cardholder.md
@@ -33,5 +33,5 @@ Example response (snippet):
 }
 ```
 
-The field {{% highlight_text %}}card[name]{{% /highlight_text %}} is mandatory for Mastercard payment of winnings (gaming/gambling merchants).
+The field {{% highlight_text %}}card[name]{{% /highlight_text %}} is mandatory for Mastercard Payment of winnings (gaming/gambling merchants).
 Depending on card scheme and merchant category, the name on the card might be necessary for approval of credits.

--- a/website/content/gateway/examples/payout_to_cardholder/payout_to_cardholder.md
+++ b/website/content/gateway/examples/payout_to_cardholder/payout_to_cardholder.md
@@ -32,4 +32,6 @@ Example response (snippet):
     "currency": "EUR"
 }
 ```
-Depending on card scheme and merchant category, the name on the card might be necessary for approval of credits. It may be provided through the optional parameter {{% highlight_text %}}card[name]{{% /highlight_text %}}.
+
+The field {{% highlight_text %}}card[name]{{% /highlight_text %}} is mandatory for Mastercard payment of winnings (gaming/gambling merchants).
+Depending on card scheme and merchant category, the name on the card might be necessary for approval of credits.


### PR DESCRIPTION
From the 6th of June payment of winnings for Mastercard will require name of recipient.

Internal link: https://github.com/clearhaus/issues-project-management/issues/102