### PR TITLE
Add refunds, debits and debit refunds to endpoint summary

### DIFF
--- a/website/content/gateway/api_reference/endpoint_summary/endpoint_summary.md
+++ b/website/content/gateway/api_reference/endpoint_summary/endpoint_summary.md
@@ -13,8 +13,17 @@ https://gateway.clearhaus.com/authorizations
 # captures
 https://gateway.clearhaus.com/authorizations/:id/captures
 
+# capture refunds
+https://gateway.clearhaus.com/authorizations/:id/refunds
+
 # voids
 https://gateway.clearhaus.com/authorizations/:id/voids
+
+# debits
+https://gateway.clearhaus.com/debits
+
+# debit refunds 
+https://gateway.clearhaus.com/debits/:id/refunds
 
 # credits
 https://gateway.clearhaus.com/credits

--- a/website/content/gateway/api_reference/transaction_status/transaction_status_codes_table.md
+++ b/website/content/gateway/api_reference/transaction_status/transaction_status_codes_table.md
@@ -4,27 +4,27 @@ date: 2022-04-13T12:37:22+02:00
 anchor: "transaction-status-codes-table"
 weight: 195
 ---
-| Status   | code  | Meaning                            | Auth | Capture | Refund | Void | Credit |
-| -------- | ----- | ---------------------------------- | ---- | ------- | ------ | ---- | ------ |
-| Approved | 20000 | Approved                           | ✓    | ✓       | ✓      | ✓    | ✓      |
-| Declined | 40000 | General input error                | ✓    | ✓       | ✓      | ✓    | ✓      |
-|          | 40110 | Invalid card number                | ✓    |         |        |      | ✓      |
-|          | 40111 | Unsupported card scheme            | ✓    |         |        |      | ✓      |
-|          | 40120 | Invalid CSC                        | ✓    |         |        |      |        |
-|          | 40130 | Invalid expire date                | ✓    |         |        |      | ✓      |
-|          | 40135 | Card expired                       | ✓    |         |        |      | ✓      |
-|          | 40140 | Invalid currency                   | ✓    |         |        |      | ✓      |
-|          | 40150 | Invalid text on statement          | ✓    | ✓       | ✓      |      | ✓      |
-|          | 40200 | Clearhaus rule violation           | ✓    | ✓       | ✓      | ✓    | ✓      |
-|          | 40300 | 3-D Secure problem                 | ✓    |         |        |      |        |
-|          | 40310 | 3-D Secure authentication failure  | ✓    |         |        |      |        |
-|          | 40400 | Backend problem                    | ✓    |         |        | ✓    | ✓      |
-|          | 40410 | Declined by issuer or card scheme  | ✓    |         |        | ✓    | ✓      |
-|          | 40411 | Card restricted                    | ✓    |         |        |      | ✓      |
-|          | 40412 | Card lost or stolen                | ✓    |         |        |      | ✓      |
-|          | 40413 | Insufficient funds                 | ✓    |         |        |      | ✓      |
-|          | 40414 | Suspected fraud                    | ✓    |         |        |      | ✓      |
-|          | 40415 | Amount limit exceeded              | ✓    |         |        |      | ✓      |
-|          | 40416 | Additional authentication required | ✓    |         |        |      | ✓      |
-|          | 40420 | Merchant blocked by cardholder     | ✓    |         |        |      | ✓      |
-|          | 50000 | Clearhaus error                    | ✓    | ✓       | ✓      | ✓    | ✓      |
+| Status   | code  | Meaning                            | Auth | Capture | Refund | Void | Credit | Debit  | Debit Refund |
+|----------|-------|------------------------------------|------|---------|--------|------|--------|--------|--------------|
+| Approved | 20000 | Approved                           | ✓    | ✓       | ✓      | ✓    | ✓      | ✓      | ✓            |
+| Declined | 40000 | General input error                | ✓    | ✓       | ✓      | ✓    | ✓      | ✓      | ✓            |
+|          | 40110 | Invalid card number                | ✓    |         |        |      | ✓      | ✓      |              |
+|          | 40111 | Unsupported card scheme            | ✓    |         |        |      | ✓      | ✓      |              |
+|          | 40120 | Invalid CSC                        | ✓    |         |        |      |        | ✓      |              |
+|          | 40130 | Invalid expire date                | ✓    |         |        |      | ✓      | ✓      |              |
+|          | 40135 | Card expired                       | ✓    |         |        |      | ✓      | ✓      |              |
+|          | 40140 | Invalid currency                   | ✓    |         |        |      | ✓      | ✓      | ✓            |
+|          | 40150 | Invalid text on statement          | ✓    | ✓       | ✓      |      | ✓      | ✓      |              |
+|          | 40200 | Clearhaus rule violation           | ✓    | ✓       | ✓      | ✓    | ✓      | ✓      |              |
+|          | 40300 | 3-D Secure problem                 | ✓    |         |        |      |        | ✓      |              |
+|          | 40310 | 3-D Secure authentication failure  | ✓    |         |        |      |        | ✓      |              |
+|          | 40400 | Backend problem                    | ✓    |         |        | ✓    | ✓      | ✓      | ✓            |
+|          | 40410 | Declined by issuer or card scheme  | ✓    |         |        | ✓    | ✓      | ✓      | ✓            |
+|          | 40411 | Card restricted                    | ✓    |         |        |      | ✓      | ✓      | ✓            |
+|          | 40412 | Card lost or stolen                | ✓    |         |        |      | ✓      | ✓      | ✓            |
+|          | 40413 | Insufficient funds                 | ✓    |         |        |      | ✓      | ✓      | ✓            |
+|          | 40414 | Suspected fraud                    | ✓    |         |        |      | ✓      | ✓      | ✓            |
+|          | 40415 | Amount limit exceeded              | ✓    |         |        |      | ✓      | ✓      | ✓            |
+|          | 40416 | Additional authentication required | ✓    |         |        |      | ✓      | ✓      | ✓            |
+|          | 40420 | Merchant blocked by cardholder     | ✓    |         |        |      | ✓      |        |              |
+|          | 50000 | Clearhaus error                    | ✓    | ✓       | ✓      | ✓    | ✓      | ✓      | ✓            |


### PR DESCRIPTION
I've found that we are missing some endpoint in Endpoint summary.
![image](https://user-images.githubusercontent.com/3591989/236142939-fe0857c7-f9df-468e-9fd3-45ee01bbe386.png)

This will add them. Served locally:
![image](https://user-images.githubusercontent.com/3591989/236143102-70a28f2c-36a4-4d85-a2cc-383ed199bfd8.png)
