### PR TITLE
Explicitly state that amount must be greater than zero.

### DIFF
--- a/website/content/gateway/api_reference/resources/debits/debits.md
+++ b/website/content/gateway/api_reference/resources/debits/debits.md
@@ -9,7 +9,7 @@ To transfer money from a cardholder's bank account in real-time, in one step, yo
 ```shell
 POST https://gateway.clearhaus.com/debits
 ```
-Debits support the same parameters and payment methods as [Authorizations](#authorizations), with the exception that 3-D Secure version 1 is not supported.
+Debits support the same parameters and payment methods as [Authorizations](#authorizations), with the exception that amount must be greater than zero.
 
 Under certain circumstances, sender information is required for a debit. See [Sender information](#sender_information).
 


### PR DESCRIPTION
Visa Direct does not allow for debits with amount zero. This will be stated by this update to our documentation.

I've remove the exception related to 3DSv1 as this was removed from the documentation elsewhere by https://github.com/clearhaus/gateway-api-docs/commit/a93ddde0210227935ccf129f192a29316f3c459f