### PR TITLE
Add support for recipient information on `debits`

### DIFF
--- a/website/content/gateway/api_reference/changes/changes.md
+++ b/website/content/gateway/api_reference/changes/changes.md
@@ -10,6 +10,11 @@ Follow coming changes on the [source code repository](https://github.com/clearha
 
 Sorted by descending timestamp.
 
+#### Add recipient to debits
+The `recipient` concept have been added to debits. The
+`recipient[account_number]` and `recipient[name]` is now required for merchant
+accounts with BAI AA from 2023-07-31.
+
 #### Removal of deprecated parameters
 We are removing several parameters that have been deprecated for an extended
 period of time. We promise that the following parameters are functional until

--- a/website/content/gateway/api_reference/changes/changes.md
+++ b/website/content/gateway/api_reference/changes/changes.md
@@ -13,7 +13,8 @@ Sorted by descending timestamp.
 #### Add recipient to debits
 The `recipient` concept has been added to debits. The
 `recipient[account_number]` and `recipient[name]` parameters are now required
-for merchant accounts with BAI AA from 2023-07-31.
+for merchant accounts with Business Application Identifier (BAI)
+Account-to-Account (AA) from 2023-07-31.
 
 #### Removal of deprecated parameters
 We are removing several parameters that have been deprecated for an extended

--- a/website/content/gateway/api_reference/changes/changes.md
+++ b/website/content/gateway/api_reference/changes/changes.md
@@ -11,9 +11,9 @@ Follow coming changes on the [source code repository](https://github.com/clearha
 Sorted by descending timestamp.
 
 #### Add recipient to debits
-The `recipient` concept have been added to debits. The
-`recipient[account_number]` and `recipient[name]` is now required for merchant
-accounts with BAI AA from 2023-07-31.
+The `recipient` concept has been added to debits. The
+`recipient[account_number]` and `recipient[name]` parameters are now required
+for merchant accounts with BAI AA from 2023-07-31.
 
 #### Removal of deprecated parameters
 We are removing several parameters that have been deprecated for an extended

--- a/website/content/gateway/api_reference/resources/authorizations/authorizations_methods/card.md
+++ b/website/content/gateway/api_reference/resources/authorizations/authorizations_methods/card.md
@@ -21,12 +21,12 @@ weight: 110
 {{% description_term %}}card[csc] {{% regex %}}[0-9]{3}{{% /regex %}}{{% /description_term %}}
 {{% description_details %}}Card Security Code.
 
-{{% regex_optional %}}Optional when partner is trusted{{% /regex_optional %}}
+{{% regex_optional %}}Optional when partner is trusted.{{% /regex_optional %}}
 {{% /description_details %}}
 
 {{% description_term %}}card[3dsecure] {{% regex %}}dictionary{{% /regex %}}{{% /description_term %}}
 {{% description_details %}}See [Authentication: [3dsecure]](#authentication-3dsecure).
-{{% regex_optional %}}Optional{{% /regex_optional %}}
+{{% regex_optional %}}Optional.{{% /regex_optional %}}
 {{% /description_details %}}
 {{% /description_list %}}
 {{% notice %}}

--- a/website/content/gateway/api_reference/resources/credits/credits.md
+++ b/website/content/gateway/api_reference/resources/credits/credits.md
@@ -22,22 +22,22 @@ POST https://gateway.clearhaus.com/credits
 {{% description_term %}}text_on_statement{{% regex %}}[\x20-\x7E]{2,22} [ASCII printable characters](https://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters) {{% /regex %}}{{% /description_term %}}
 {{% description_details %}}Text that will be placed on cardholder’s bank statement.
 
-{{% regex_optional %}} May not be all digits, all same character, or all sequential characters (e.g. “abc”){{% /regex_optional %}}
-{{% regex_optional %}}Optional, defaults to account's descriptor{{% /regex_optional %}}
+{{% regex_optional %}}May not be all digits, all same character, or all sequential characters (e.g. “abc”).{{% /regex_optional %}}
+{{% regex_optional %}}Optional, defaults to account's descriptor.{{% /regex_optional %}}
 {{% /description_details %}}
 
 {{% description_term %}}reference{{% regex %}}[\x20-\x7E]{1,30} [ASCII printable characters](https://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters) {{% /regex %}}{{% /description_term %}}
-{{% description_details %}} A reference to an external object, such as an order number. 
+{{% description_details %}} A reference to an external object, such as an order number.
 
 {{% regex_optional %}}Optional{{% /regex_optional %}}
 {{% /description_details %}}
 
 {{% description_term %}}card[pan] {{% regex %}}[0-9]{12,19}{{% /regex %}}{{% /description_term %}}
-{{% description_details %}}Primary account number of card to charge. 
+{{% description_details %}}Primary account number of card to charge.
 {{% /description_details %}}
 
 {{% description_term %}}card[expire_month] {{% regex %}}[0-9]{2}{{% /regex %}}{{% /description_term %}}
-{{% description_details %}}Expiry month of card to charge. 
+{{% description_details %}}Expiry month of card to charge.
 {{% /description_details %}}
 
 {{% description_term %}}card[expire_year] {{% regex %}}20[0-9]{2}{{% /regex %}}{{% /description_term %}}
@@ -45,17 +45,17 @@ POST https://gateway.clearhaus.com/credits
 {{% /description_details %}}
 
 {{% description_term %}}card[csc] {{% regex %}} [0-9]{3}{{% /regex %}}{{% /description_term %}}
-{{% description_details %}}Card Security Code. 
-{{% regex_optional %}}Optional{{% /regex_optional %}}
+{{% description_details %}}Card Security Code.
+{{% regex_optional %}}Optional.{{% /regex_optional %}}
 {{% /description_details %}}
 
 {{% description_term %}}card[name] {{% regex %}}[A-Za-z0-9 ]{1,30}{{% /regex %}}{{% /description_term %}}
-{{% description_details %}}Name on card. 
-{{% regex_optional %}}Required for Mastercard Payment of winnings, otherwise optional{{% /regex_optional %}}
+{{% description_details %}}Name on card.
+{{% regex_optional %}}Required for Mastercard Payment of winnings, otherwise optional.{{% /regex_optional %}}
 {{% /description_details %}}
 
 {{% /description_list %}}
 
 {{% notice %}}
-**Notice**: Implicitly, `initiator` is `merchant` and `credential_on_file` is `use`. 
+**Notice**: Implicitly, `initiator` is `merchant` and `credential_on_file` is `use`.
 {{% /notice %}}

--- a/website/content/gateway/api_reference/resources/debits/debits.md
+++ b/website/content/gateway/api_reference/resources/debits/debits.md
@@ -11,7 +11,7 @@ POST https://gateway.clearhaus.com/debits
 ```
 Debits support the same parameters and payment methods as [Authorizations](#authorizations), with the exception that amount must be greater than zero.
 
-Under certain circumstances, sender and recipient information is required for a debit. See [Sender information](#sender_information) and [Recipient information](#recipient_information).
+Information about sender and recipient is required for debits under certain circumstances to be compliant with card scheme rules. See [Sender information](#sender_information) and [Recipient information](#recipient_information).
 
 {{% notice %}}
 **Notice:** Debits are only supported for Visa cards. Currently, only merchants with selected Merchant Category Codes (MCCs) and assigned Business Application Identifiers (BAIs) are able to process a debit; namely exactly those that will result in the debit being a Visa Account Funding Transaction (AFT).

--- a/website/content/gateway/api_reference/resources/debits/debits.md
+++ b/website/content/gateway/api_reference/resources/debits/debits.md
@@ -11,7 +11,7 @@ POST https://gateway.clearhaus.com/debits
 ```
 Debits support the same parameters and payment methods as [Authorizations](#authorizations), with the exception that amount must be greater than zero.
 
-Under certain circumstances, sender information is required for a debit. See [Sender information](#sender_information).
+Under certain circumstances, sender and recipient information is required for a debit. See [Sender information](#sender_information) and [Recipient information](#recipient_information).
 
 {{% notice %}}
 **Notice:** Debits are only supported for Visa cards. Currently, only merchants with selected Merchant Category Codes (MCCs) and assigned Business Application Identifiers (BAIs) are able to process a debit; namely exactly those that will result in the debit being a Visa Account Funding Transaction (AFT).

--- a/website/content/gateway/api_reference/resources/debits/recipient_information.md
+++ b/website/content/gateway/api_reference/resources/debits/recipient_information.md
@@ -5,6 +5,7 @@ anchor: "recipient_information"
 weight: 178
 ---
 ##### Recipient information
+See the partner guideline for more details.
 
 {{% description_list %}}
 

--- a/website/content/gateway/api_reference/resources/debits/recipient_information.md
+++ b/website/content/gateway/api_reference/resources/debits/recipient_information.md
@@ -14,7 +14,7 @@ weight: 178
 Example: "Doe Jane A." (last name, first name, optional middle initial).
 
 {{% regex_optional %}}It must not contain special characters (?, @, #, $, &, \*, etc.), be all numeric, be fictious, be a nickname or be incomplete (only first or last name).{{% /regex_optional %}}
-{{% regex_optional %}}Required for intra-EEA and international debits. Also required if any of the address-related parameters are supplied.{{% /regex_optional %}}
+{{% regex_optional %}}Required.{{% /regex_optional %}}
 {{% /description_details %}}
 
 {{% description_term %}}recipient[account_number] {{% regex %}}[\x20-\x7E]{1,34} [ASCII printable characters](https://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters){{% /regex %}}{{% /description_term %}}

--- a/website/content/gateway/api_reference/resources/debits/recipient_information.md
+++ b/website/content/gateway/api_reference/resources/debits/recipient_information.md
@@ -19,5 +19,5 @@ Example: "Doe Jane A." (last name, first name, optional middle initial).
 
 {{% description_term %}}recipient[account_number] {{% regex %}}[\x20-\x7E]{1,34} [ASCII printable characters](https://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters){{% /regex %}}{{% /description_term %}}
 {{% description_details %}}The recipient's account number, i.e. an identification of the account being funded by the debit. It can be an IBAN, a proprietary wallet number, a PAN, etc.
-{{% regex_optional %}}Required{{% /regex_optional %}}
+{{% regex_optional %}}Required.{{% /regex_optional %}}
 {{% /description_details %}}

--- a/website/content/gateway/api_reference/resources/debits/recipient_information.md
+++ b/website/content/gateway/api_reference/resources/debits/recipient_information.md
@@ -18,6 +18,6 @@ Example: "Doe Jane A." (last name, first name, optional middle initial).
 {{% /description_details %}}
 
 {{% description_term %}}recipient[account_number] {{% regex %}}[\x20-\x7E]{1,34} [ASCII printable characters](https://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters){{% /regex %}}{{% /description_term %}}
-{{% description_details %}}The recipient's account number, i.e. an identification of the account being funded by the debit. It can be an IBAN, a proprietary wallet number, a prepaid PAN, etc.
+{{% description_details %}}The recipient's account number, i.e. an identification of the account being funded by the debit. It can be an IBAN, a proprietary wallet number, a PAN, etc.
 {{% regex_optional %}}Required{{% /regex_optional %}}
 {{% /description_details %}}

--- a/website/content/gateway/api_reference/resources/debits/recipient_information.md
+++ b/website/content/gateway/api_reference/resources/debits/recipient_information.md
@@ -21,3 +21,10 @@ Example: "Doe Jane A." (last name, first name, optional middle initial).
 {{% description_details %}}The recipient's account number, i.e. an identification of the account being funded by the debit. It can be an IBAN, a proprietary wallet number, a PAN, etc.
 {{% regex_optional %}}Required.{{% /regex_optional %}}
 {{% /description_details %}}
+
+{{% description_term %}}recipient[reference] {{% regex %}}[\x20-\x7E]{1,16} [ASCII printable characters](https://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters){{% /regex %}}{{% /description_term %}}
+{{% description_details %}}Recipient reference number. You must be able to uniquely identify the recipient using this number.
+{{% regex_optional %}}Required if the merchant account's Business Application Identifier (BAI) is Funds Disbursement (FD).{{% /regex_optional %}}
+{{% /description_details %}}
+
+{{% /description_list %}}

--- a/website/content/gateway/api_reference/resources/debits/recipient_information.md
+++ b/website/content/gateway/api_reference/resources/debits/recipient_information.md
@@ -1,0 +1,23 @@
+---
+title: "recipient_information"
+date: 2023-07-20T13:01:49+01:00
+anchor: "recipient_information"
+weight: 178
+---
+##### Recipient information
+
+{{% description_list %}}
+
+{{% description_term %}}recipient[name] {{% regex %}}[\x20-\x7E]{2,30} [ASCII printable characters](https://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters){{% /regex %}}{{% /description_term %}}
+{{% description_details %}}The recipient's legal name.
+
+Example: "Doe Jane A." (last name, first name, optional middle initial).
+
+{{% regex_optional %}}It must not contain special characters (?, @, #, $, &, \*, etc.), be all numeric, be fictious, be a nickname or be incomplete (only first or last name).{{% /regex_optional %}}
+{{% regex_optional %}}Required for intra-EEA and international debits. Also required if any of the address-related parameters are supplied.{{% /regex_optional %}}
+{{% /description_details %}}
+
+{{% description_term %}}recipient[account_number] {{% regex %}}[\x20-\x7E]{1,34} [ASCII printable characters](https://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters){{% /regex %}}{{% /description_term %}}
+{{% description_details %}}The recipient's account number, i.e. an identification of the account being funded by the debit. It can be an IBAN, a proprietary wallet number, a prepaid PAN, etc.
+{{% regex_optional %}}Required{{% /regex_optional %}}
+{{% /description_details %}}

--- a/website/content/gateway/api_reference/resources/debits/sender_information.md
+++ b/website/content/gateway/api_reference/resources/debits/sender_information.md
@@ -40,11 +40,6 @@ Example: "Doe Jane A." (last name, first name, optional middle initial).
 {{% regex_optional %}}Required for intra-EEA and international debits.{{% /regex_optional %}}
 {{% /description_details %}}
 
-{{% description_term %}}sender[account_number] {{% regex %}}[\x20-\x7E]{1,34} [ASCII printable characters](https://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters){{% /regex %}}{{% /description_term %}}
-{{% description_details %}}The sender's account number, i.e. an identification of the account being funded by the debit. It can be an IBAN, a proprietary wallet number, a prepaid PAN, etc.
-{{% regex_optional %}}Required{{% /regex_optional %}}
-{{% /description_details %}}
-
 {{% description_term %}}sender[reference] {{% regex %}}[\x20-\x7E]{1,16} [ASCII printable characters](https://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters){{% /regex %}}{{% /description_term %}}
 {{% description_details %}}Sender reference number. You must be able to uniquely identify the sender using this number.
 {{% regex_optional %}}Required if the merchant account's Business Application Identifier (BAI) is Funds Disbursement (FD).{{% /regex_optional %}}

--- a/website/content/gateway/api_reference/resources/debits/sender_information.md
+++ b/website/content/gateway/api_reference/resources/debits/sender_information.md
@@ -5,7 +5,7 @@ anchor: "sender_information"
 weight: 177
 ---
 ##### Sender information
-Information about the sender is required for debits under certain circumstances to be compliant with card scheme rules. See the partner guideline for more details.
+See the partner guideline for more details.
 
 Intra-EEA, mentioned below, includes the United Kingdom and Gibraltar.
 

--- a/website/content/gateway/api_reference/resources/debits/sender_information.md
+++ b/website/content/gateway/api_reference/resources/debits/sender_information.md
@@ -40,9 +40,4 @@ Example: "Doe Jane A." (last name, first name, optional middle initial).
 {{% regex_optional %}}Required for intra-EEA and international debits.{{% /regex_optional %}}
 {{% /description_details %}}
 
-{{% description_term %}}sender[reference] {{% regex %}}[\x20-\x7E]{1,16} [ASCII printable characters](https://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters){{% /regex %}}{{% /description_term %}}
-{{% description_details %}}Sender reference number. You must be able to uniquely identify the sender using this number.
-{{% regex_optional %}}Required if the merchant account's Business Application Identifier (BAI) is Funds Disbursement (FD).{{% /regex_optional %}}
-{{% /description_details %}}
-
 {{% /description_list %}}


### PR DESCRIPTION
`recipient` concept added to `debits`. Adding `recipient[name]` and `recipient[account_number]` replaces `sender[account_number]`.