### PR TITLE
Add `marketplace[interregional_retailer]` to captures and capture refunds

### DIFF
--- a/website/content/gateway/api_reference/changes/changes.md
+++ b/website/content/gateway/api_reference/changes/changes.md
@@ -10,10 +10,10 @@ Follow coming changes on the [source code repository](https://github.com/clearha
 
 Sorted by descending timestamp.
 
-#### Add marketplace regional purchase indicator to captures and capture refunds
-The `marketplace` concept has been added to captures and capture refunds. The
-`marketplace[regional_purchase]` parameter is required if the merchant is a
-marketplace.
+#### Add marketplace interregional retailer indicator to captures and capture refunds
+A `marketplace` concept has been added to captures and capture refunds. The
+`marketplace[interregional_retailer]` parameter is required if the merchant is
+a marketplace.
 
 #### Add recipient to debits
 The `recipient` concept has been added to debits. The

--- a/website/content/gateway/api_reference/changes/changes.md
+++ b/website/content/gateway/api_reference/changes/changes.md
@@ -10,6 +10,10 @@ Follow coming changes on the [source code repository](https://github.com/clearha
 
 Sorted by descending timestamp.
 
+#### Add marketplace regional purchase indicator to captures and capture refunds
+The `marketplace` concept has been added to captures and capture refunds. The
+`marketplace[regional_purchase]` parameter is optional with default `true`.
+
 #### Add recipient to debits
 The `recipient` concept has been added to debits. The
 `recipient[account_number]` and `recipient[name]` parameters are now required

--- a/website/content/gateway/api_reference/changes/changes.md
+++ b/website/content/gateway/api_reference/changes/changes.md
@@ -12,7 +12,8 @@ Sorted by descending timestamp.
 
 #### Add marketplace regional purchase indicator to captures and capture refunds
 The `marketplace` concept has been added to captures and capture refunds. The
-`marketplace[regional_purchase]` parameter is optional with default `true`.
+`marketplace[regional_purchase]` parameter is required if the merchant is a
+marketplace.
 
 #### Add recipient to debits
 The `recipient` concept has been added to debits. The

--- a/website/content/gateway/api_reference/resources/capture_refunds/capture_refunds.md
+++ b/website/content/gateway/api_reference/resources/capture_refunds/capture_refunds.md
@@ -27,6 +27,13 @@ These are refunds of one or more captures made on an authorization and shall not
 {{% regex_optional %}}Optional{{% /regex_optional %}}
 {{% /description_details %}}
 
+{{% description_term %}}marketplace[regional_purchase]{{% regex %}}(true|false){{% /regex %}}{{% /description_term %}}
+{{% description_details %}}Indicates whether a marketplace purchase is regional or not.
+
+Default: `true`.
+{{% regex_optional %}}Optional{{% /regex_optional %}}
+{{% /description_details %}}
+
 {{% /description_list %}}
 
 {{% notice %}}

--- a/website/content/gateway/api_reference/resources/capture_refunds/capture_refunds.md
+++ b/website/content/gateway/api_reference/resources/capture_refunds/capture_refunds.md
@@ -27,8 +27,8 @@ These are refunds of one or more captures made on an authorization and shall not
 {{% regex_optional %}}Optional{{% /regex_optional %}}
 {{% /description_details %}}
 
-{{% description_term %}}marketplace[regional_purchase]{{% regex %}}(true|false){{% /regex %}}{{% /description_term %}}
-{{% description_details %}}Indicates whether a marketplace purchase is regional or not.
+{{% description_term %}}marketplace[interregional_retailer]{{% regex %}}(true|false){{% /regex %}}{{% /description_term %}}
+{{% description_details %}}Indicates whether or not a marketplace retailer outside EEA, Gibraltar, and the UK is involved in the transaction.
 
 {{% regex_optional %}}Required if the merchant is a marketplace.{{% /regex_optional %}}
 {{% /description_details %}}

--- a/website/content/gateway/api_reference/resources/capture_refunds/capture_refunds.md
+++ b/website/content/gateway/api_reference/resources/capture_refunds/capture_refunds.md
@@ -30,8 +30,7 @@ These are refunds of one or more captures made on an authorization and shall not
 {{% description_term %}}marketplace[regional_purchase]{{% regex %}}(true|false){{% /regex %}}{{% /description_term %}}
 {{% description_details %}}Indicates whether a marketplace purchase is regional or not.
 
-Default: `true`.
-{{% regex_optional %}}Optional{{% /regex_optional %}}
+{{% regex_optional %}}Required if the merchant is a marketplace.{{% /regex_optional %}}
 {{% /description_details %}}
 
 {{% /description_list %}}

--- a/website/content/gateway/api_reference/resources/captures/captures.md
+++ b/website/content/gateway/api_reference/resources/captures/captures.md
@@ -31,8 +31,7 @@ POST https://gateway.clearhaus.com/authorizations/:id/captures
 {{% description_term %}}marketplace[regional_purchase]{{% regex %}}(true|false){{% /regex %}}{{% /description_term %}}
 {{% description_details %}}Indicates whether a marketplace purchase is regional or not.
 
-Default: `true`.
-{{% regex_optional %}}Optional{{% /regex_optional %}}
+{{% regex_optional %}}Required if the merchant is a marketplace.{{% /regex_optional %}}
 {{% /description_details %}}
 
 {{% /description_list %}}

--- a/website/content/gateway/api_reference/resources/captures/captures.md
+++ b/website/content/gateway/api_reference/resources/captures/captures.md
@@ -28,8 +28,8 @@ POST https://gateway.clearhaus.com/authorizations/:id/captures
 {{% regex_optional %}}Optional{{% /regex_optional %}}
 {{% /description_details %}}
 
-{{% description_term %}}marketplace[regional_purchase]{{% regex %}}(true|false){{% /regex %}}{{% /description_term %}}
-{{% description_details %}}Indicates whether a marketplace purchase is regional or not.
+{{% description_term %}}marketplace[interregional_retailer]{{% regex %}}(true|false){{% /regex %}}{{% /description_term %}}
+{{% description_details %}}Indicates whether or not a marketplace retailer outside EEA, Gibraltar, and the UK is involved in the transaction.
 
 {{% regex_optional %}}Required if the merchant is a marketplace.{{% /regex_optional %}}
 {{% /description_details %}}

--- a/website/content/gateway/api_reference/resources/captures/captures.md
+++ b/website/content/gateway/api_reference/resources/captures/captures.md
@@ -28,6 +28,13 @@ POST https://gateway.clearhaus.com/authorizations/:id/captures
 {{% regex_optional %}}Optional{{% /regex_optional %}}
 {{% /description_details %}}
 
+{{% description_term %}}marketplace[regional_purchase]{{% regex %}}(true|false){{% /regex %}}{{% /description_term %}}
+{{% description_details %}}Indicates whether a marketplace purchase is regional or not.
+
+Default: `true`.
+{{% regex_optional %}}Optional{{% /regex_optional %}}
+{{% /description_details %}}
+
 {{% /description_list %}}
 
 {{% notice %}}


### PR DESCRIPTION
We are extending our API to support Visa's Foreign Retail Indicator (FRI) for marketplaces. We have chosen to rephrase this to `marketplace[interregional_retailer]`.

The parameter will be required when a merchant is a marketplace. The conditional requirement will be the same for both Visa and Mastercard.