### PR TITLE
Mention funding transactions in debits notice block

### DIFF
--- a/website/content/gateway/api_reference/resources/debits/debits.md
+++ b/website/content/gateway/api_reference/resources/debits/debits.md
@@ -14,5 +14,5 @@ Debits support the same parameters and payment methods as [Authorizations](#auth
 Information about sender and recipient is required for debits under certain circumstances to be compliant with card scheme rules. See [Sender information](#sender_information) and [Recipient information](#recipient_information).
 
 {{% notice %}}
-**Notice:** Debits are only supported for Visa cards and for non-marketplace merchants. In addition, only merchants with selected Merchant Category Codes (MCCs) and assigned Business Application Identifiers (BAIs) are able to process a debit; namely exactly those that will result in the debit being a Visa Account Funding Transaction (AFT).
+**Notice:** Debits are only supported for Visa cards and funding transactions. In addition, only merchants with selected Merchant Category Codes (MCCs) and assigned Business Application Identifiers (BAIs) are able to process a debit; namely exactly those that will result in the debit being a Visa Account Funding Transaction (AFT).
 {{% /notice %}}

--- a/website/content/gateway/api_reference/resources/debits/debits.md
+++ b/website/content/gateway/api_reference/resources/debits/debits.md
@@ -14,5 +14,5 @@ Debits support the same parameters and payment methods as [Authorizations](#auth
 Information about sender and recipient is required for debits under certain circumstances to be compliant with card scheme rules. See [Sender information](#sender_information) and [Recipient information](#recipient_information).
 
 {{% notice %}}
-**Notice:** Debits are only supported for Visa cards. Currently, only merchants with selected Merchant Category Codes (MCCs) and assigned Business Application Identifiers (BAIs) are able to process a debit; namely exactly those that will result in the debit being a Visa Account Funding Transaction (AFT).
+**Notice:** Debits are only supported for Visa cards and for non-marketplace merchants. In addition, only merchants with selected Merchant Category Codes (MCCs) and assigned Business Application Identifiers (BAIs) are able to process a debit; namely exactly those that will result in the debit being a Visa Account Funding Transaction (AFT).
 {{% /notice %}}


### PR DESCRIPTION
The original reason for this was that debits are not supported for marketplace merchants, however, the more "general" reasoning is that our debits currently support funding transactions (on Visa cards).