### PR TITLE
Add MIT recommendation to token[m4m][tav]

### DIFF
--- a/website/content/gateway/api_reference/resources/authorizations/authorizations_methods/token.md
+++ b/website/content/gateway/api_reference/resources/authorizations/authorizations_methods/token.md
@@ -53,7 +53,7 @@ Found in `eci` (SCOF). (Not available in MDES.)
 Only DSRP cryptograms are supported. The value must start with `[A-P]` to be a DSRP cryptogram.
 
 Found in `encryptedPayload.encryptedData.de48se43Data` (MDES) or `encryptedPayload.dynamicData.dynamicDataValue` (SCOF).
-{{% regex_optional %}}Required for CITs; otherwise optional.{{% /regex_optional %}}
+{{% regex_optional %}}Required for CITs. For MITs it shall only be included on the first, tokenized transaction or if there is a change to the token.{{% /regex_optional %}}
 {{% /description_details %}}
 
 {{% description_term %}}token[m4m][rcai] {{% regex %}}[:base64:]{1..150}{{% /regex %}}{{% /description_term %}}


### PR DESCRIPTION
Prompted by the fact that upstream declines subsequent MITs with a TAV. Only the first, tokenized MIT is allowed to include the TAV. An exception is if/when a token changes, i.e. its TAN or expiry change.

Rendering:

![Screenshot from 2024-01-22 10-10-57](https://github.com/clearhaus/gateway-api-docs/assets/14069221/99cb7fac-aac4-4627-9ff4-bc5279087dec)
