### PR TITLE
Add notice to sca_exemption parameter

### DIFF
--- a/website/content/gateway/api_reference/resources/authorizations/authorizations.md
+++ b/website/content/gateway/api_reference/resources/authorizations/authorizations.md
@@ -90,7 +90,9 @@ If the latest approved authorization in the series was not processed via Clearha
 {{% regex_optional %}}Mutually exclusive with `series`.{{% /regex_optional %}}
 
 {{% notice %}}
-**Notice:** Please be aware that rules to disallow authorizations with `sca_exemption` may be in place for a merchant.
+**Notice:** Rules to disallow authorizations with `sca_exemption` may be in place for a merchant.
+
+**Notice:** The exemption will be requested upstream regardless of the necessity of SCA.
 {{% /notice %}}
 {{% /description_details %}}
 


### PR DESCRIPTION
To make it clear we honor the request even in a situation where SCA is not required, e.g. one leg out.

Rendering:

![Screenshot from 2024-02-20 09-09-29](https://github.com/clearhaus/gateway-api-docs/assets/14069221/743a0743-482b-4fe5-9b55-bafa673b5ba2)
