### PR TITLE
Remove token[m4m][eci] parameter

### DIFF
--- a/website/content/gateway/api_reference/changes/changes.md
+++ b/website/content/gateway/api_reference/changes/changes.md
@@ -12,9 +12,8 @@ Sorted by descending timestamp.
 
 #### Removal of `token[m4m][eci]` parameter
 Starting 2024-05-15, the `token[m4m][eci]` parameter has been removed. As the
-API accepts unknown parameters in general, this means that the parameter is now
-being ignored. It is recommended that the parameter is no longer sent to the
-transaction gateway.
+API accepts unknown parameters in general, the parameter can still be sent. It
+is, however, recommended that the parameter is omitted to avoid confusion.
 
 #### Addition of `sca_exemption` parameter
 Starting 2024-02-09, the `sca_exemption` parameter is available for

--- a/website/content/gateway/api_reference/changes/changes.md
+++ b/website/content/gateway/api_reference/changes/changes.md
@@ -10,6 +10,12 @@ Follow coming changes on the [source code repository](https://github.com/clearha
 
 Sorted by descending timestamp.
 
+#### Removal of `token[m4m][eci]` parameter
+Starting 2024-05-15, the `token[m4m][eci]` parameter has been removed. As the
+API accepts unknown parameters in general, this means that the parameter is now
+being ignored. It is recommended that the parameter is no longer sent to the
+transaction gateway.
+
 #### Addition of `sca_exemption` parameter
 Starting 2024-02-09, the `sca_exemption` parameter is available for
 authorizations and debits.

--- a/website/content/gateway/api_reference/changes/changes.md
+++ b/website/content/gateway/api_reference/changes/changes.md
@@ -11,7 +11,7 @@ Follow coming changes on the [source code repository](https://github.com/clearha
 Sorted by descending timestamp.
 
 #### Removal of `token[m4m][eci]` parameter
-Starting 2024-05-15, the `token[m4m][eci]` parameter has been removed. As the
+Starting 2024-06-03, the `token[m4m][eci]` parameter has been removed. As the
 API accepts unknown parameters in general, the parameter can still be sent. It
 is, however, recommended that the parameter is omitted to avoid confusion.
 

--- a/website/content/gateway/api_reference/resources/authorizations/authorizations_methods/token.md
+++ b/website/content/gateway/api_reference/resources/authorizations/authorizations_methods/token.md
@@ -40,13 +40,6 @@ Found in `encryptedPayload.encryptedData.applicationExpiryDate` (MDES) or `encry
 Found in `encryptedPayload.encryptedData.applicationExpiryDate` (MDES) or `encryptedPayload.token.tokenExpirationYear` (SCOF).
 {{% /description_details %}}
 
-{{% description_term %}}token[m4m][eci] {{% regex %}}0[267]{{% /regex %}}{{% /description_term %}}
-{{% description_details %}}Electronic Commerce Indicator.
-
-Found in `eci` (SCOF). (Not available in MDES.)
-{{% regex_optional %}}Required for CITs; otherwise optional (defaults to `07`).{{% /regex_optional %}}
-{{% /description_details %}}
-
 {{% description_term %}}token[m4m][tav] {{% regex %}}[:base64:]{28}{{% /regex %}}{{% /description_term %}}
 {{% description_details %}}Token Authentication Value (TAV). Also known as token cryptogram and Digital Secure Remote Payments (DSRP) cryptogram.
 


### PR DESCRIPTION
The parameter `token[m4m][eci]` is no longer necessary for the processing of `token[m4m]` authorizations.