### PR TITLE
Clarify applepay[raw][eci] is required for Visa

### DIFF
--- a/website/content/gateway/api_reference/resources/authorizations/authorizations_methods/applepay.md
+++ b/website/content/gateway/api_reference/resources/authorizations/authorizations_methods/applepay.md
@@ -40,6 +40,7 @@ Primary account number of card to charge.
 
 {{% description_term %}}applepay[raw][eci] {{% regex %}}[0-9]{2}{{% /regex %}}{{% /description_term %}}
 {{% description_details %}}Electronic Commerce Indicator. Found as `eciIndicator` in the payment token.
+{{% regex_optional %}}Required for Visa. Otherwise optional.{{% /regex_optional %}}
 {{% /description_details %}}
 
 


### PR DESCRIPTION
This is currently the case and should be reflected by the API documentation.

Rendering:

![Screenshot from 2024-12-19 11-03-10](https://github.com/user-attachments/assets/2faaf5c5-c46a-4cdf-9b9a-0289be54164f)
