### PR TITLE
Add Mastercard debits

### DIFF
--- a/website/content/gateway/api_reference/changes/changes.md
+++ b/website/content/gateway/api_reference/changes/changes.md
@@ -11,8 +11,8 @@ Follow coming changes on the [source code repository](https://github.com/clearha
 Sorted by descending timestamp.
 
 #### Addition of Mastercard debits
-Mastercard debits support added. The parameter `account_number_type` will be
-required for Mastercard debits.
+Mastercard debits support added. The parameter `recipient[account_number_type]`
+will be required for Mastercard debits.
 
 #### Removal of `threed_secure` property from response
 Starting 2024-11-01, an authorization response will no longer contain the

--- a/website/content/gateway/api_reference/changes/changes.md
+++ b/website/content/gateway/api_reference/changes/changes.md
@@ -11,7 +11,7 @@ Follow coming changes on the [source code repository](https://github.com/clearha
 Sorted by descending timestamp.
 
 #### Addition of Mastercard debits
-Starting 2025-04-xx, support for Mastercard debits has been added. Notice that
+Starting 2025-04-28, support for Mastercard debits has been added. Notice that
 the parameters `recipient[name]`, `recipient[account_number]` and
 `recipient[account_number_type]` are unconditionally required for Mastercard
 debits. In addition, notice that `card[name]` will be required for Mastercard

--- a/website/content/gateway/api_reference/changes/changes.md
+++ b/website/content/gateway/api_reference/changes/changes.md
@@ -10,6 +10,10 @@ Follow coming changes on the [source code repository](https://github.com/clearha
 
 Sorted by descending timestamp.
 
+#### Addition of Mastercard debits
+Mastercard debits support added. The parameter `account_number_type` will be
+required for Mastercard debits.
+
 #### Removal of `threed_secure` property from response
 Starting 2024-11-01, an authorization response will no longer contain the
 `threed_secure` property. We recommend that the `sca` dictionary is used

--- a/website/content/gateway/api_reference/changes/changes.md
+++ b/website/content/gateway/api_reference/changes/changes.md
@@ -14,8 +14,9 @@ Sorted by descending timestamp.
 Starting 2025-04-xx, support for Mastercard debits has been added. Notice that
 the parameters `recipient[name]`, `recipient[account_number]` and
 `recipient[account_number_type]` are unconditionally required for Mastercard
-debits. In addition, notice that `card[name]` will be required for all
-Mastercard credits, not only Payment of Winnings (PoW).
+debits. In addition, notice that `card[name]` will be required for Mastercard
+cross-border, non-Payment of Winnings (non-PoW) credits, not only for
+Mastercard PoW credits.
 
 #### Sender date of birth for Visa intra-EEA and international Visa debits
 Starting April 2025, the `sender[date_of_birth]` parameter is mandated for intra-EEA and

--- a/website/content/gateway/api_reference/changes/changes.md
+++ b/website/content/gateway/api_reference/changes/changes.md
@@ -11,8 +11,10 @@ Follow coming changes on the [source code repository](https://github.com/clearha
 Sorted by descending timestamp.
 
 #### Addition of Mastercard debits
-Mastercard debits support added. The parameter `recipient[account_number_type]`
-will be required for Mastercard debits.
+Starting 2025-04-xx, support for Mastercard debits has been added. Notice that
+the parameters `recipient[name]`, `recipient[account_number]` and
+`recipient[account_number_type]` are unconditionally required for Mastercard
+debits.
 
 #### Removal of `threed_secure` property from response
 Starting 2024-11-01, an authorization response will no longer contain the

--- a/website/content/gateway/api_reference/changes/changes.md
+++ b/website/content/gateway/api_reference/changes/changes.md
@@ -14,7 +14,8 @@ Sorted by descending timestamp.
 Starting 2025-04-xx, support for Mastercard debits has been added. Notice that
 the parameters `recipient[name]`, `recipient[account_number]` and
 `recipient[account_number_type]` are unconditionally required for Mastercard
-debits.
+debits. In addition, notice that `card[name]` will be required for all
+Mastercard credits, not only Payment of Winnings (PoW).
 
 #### Sender date of birth for Visa intra-EEA and international Visa debits
 Starting April 2025, the `sender[date_of_birth]` parameter is mandated for intra-EEA and

--- a/website/content/gateway/api_reference/changes/changes.md
+++ b/website/content/gateway/api_reference/changes/changes.md
@@ -20,7 +20,6 @@ debits.
 Starting April 2025, the `sender[date_of_birth]` parameter is mandated for intra-EEA and
 international Visa debits.
 
-
 #### Removal of `threed_secure` property from response
 Starting 2024-11-01, an authorization response will no longer contain the
 `threed_secure` property. We recommend that the `sca` dictionary is used

--- a/website/content/gateway/api_reference/resources/authorizations/authorizations_methods/googlepay.md
+++ b/website/content/gateway/api_reference/resources/authorizations/authorizations_methods/googlepay.md
@@ -35,7 +35,7 @@ See [Authentication: [3dsecure]](#authentication-3dsecure).
 
 **Notice**: An authorization made with `googlepay` is strongly authenticated (SCA in PSD2) if `authMethod` is `CRYPTOGRAM_3DS` and the [Google Pay guidelines for SCA](https://developers.google.com/pay/api/android/guides/resources/sca) have been followed. If `authMethod` is `PAN_ONLY`, a 3-D Secure flow is required for SCA and the resulting ARes/RReq must be supplied in the `3dsecure` sub-dictionary.
 
-**Notice**: To obtain liability shift for a `googlepay` token with `authMethod` `CRYPTOGRAM_3DS` the `ECI` must be `02` or empty for Mastercard and `05` for VISA. For other values, a 3-D Secure flow is required for liability shift.
+**Notice**: To obtain liability shift for a `googlepay` token with `authMethod` `CRYPTOGRAM_3DS` the `ECI` must be `02` or empty for Mastercard and `05` for Visa. For other values, a 3-D Secure flow is required for liability shift.
 
 **Notice**: An authorization made with `googlepay` cannot be a subsequent-in-series authorization.
 

--- a/website/content/gateway/api_reference/resources/credits/credits.md
+++ b/website/content/gateway/api_reference/resources/credits/credits.md
@@ -51,7 +51,7 @@ POST https://gateway.clearhaus.com/credits
 
 {{% description_term %}}card[name] {{% regex %}}[A-Za-z0-9 ]{1,30}{{% /regex %}}{{% /description_term %}}
 {{% description_details %}}Name on card.
-{{% regex_optional %}}Required for Mastercard.{{% /regex_optional %}}
+{{% regex_optional %}}Required for Mastercard Payment of Winnings (PoW) and for Mastercard cross-border non-PoW.{{% /regex_optional %}}
 {{% /description_details %}}
 
 {{% /description_list %}}

--- a/website/content/gateway/api_reference/resources/credits/credits.md
+++ b/website/content/gateway/api_reference/resources/credits/credits.md
@@ -51,7 +51,7 @@ POST https://gateway.clearhaus.com/credits
 
 {{% description_term %}}card[name] {{% regex %}}[A-Za-z0-9 ]{1,30}{{% /regex %}}{{% /description_term %}}
 {{% description_details %}}Name on card.
-{{% regex_optional %}}Required for Mastercard Payment of winnings, otherwise optional.{{% /regex_optional %}}
+{{% regex_optional %}}Required for Mastercard.{{% /regex_optional %}}
 {{% /description_details %}}
 
 {{% /description_list %}}

--- a/website/content/gateway/api_reference/resources/debits/debits.md
+++ b/website/content/gateway/api_reference/resources/debits/debits.md
@@ -14,5 +14,5 @@ Debits support the same parameters and payment methods as [Authorizations](#auth
 Information about sender and recipient is required for debits under certain circumstances to be compliant with card scheme rules. See [Sender information](#sender_information) and [Recipient information](#recipient_information).
 
 {{% notice %}}
-**Notice:** Debits are only supported for Visa cards and funding transactions. In addition, only merchants with selected Merchant Category Codes (MCCs) and assigned Business Application Identifiers (BAIs) are able to process a debit; namely exactly those that will result in the debit being a Visa Account Funding Transaction (AFT).
+**Notice:** Only merchants with selected Merchant Category Codes (MCCs) and assigned Business Application Identifiers (BAIs) (VISA) or Transaction Type Indicator (TTI) (Mastercard) are able to process a debit; namely exactly those that will result in the debit being a Visa or Mastercard Account Funding Transaction (AFT).
 {{% /notice %}}

--- a/website/content/gateway/api_reference/resources/debits/debits.md
+++ b/website/content/gateway/api_reference/resources/debits/debits.md
@@ -14,5 +14,5 @@ Debits support the same parameters and payment methods as [Authorizations](#auth
 Information about sender and recipient is required for debits under certain circumstances to be compliant with card scheme rules. See [Sender information](#sender_information) and [Recipient information](#recipient_information).
 
 {{% notice %}}
-**Notice:** Only merchants with selected Merchant Category Codes (MCCs) and assigned Business Application Identifiers (BAIs) (VISA) or Transaction Type Indicators (TTIs) (Mastercard) are able to process a debit; namely exactly those that will result in the debit being a Visa or Mastercard Account Funding Transaction (AFT).
+**Notice:** Only merchants with selected Merchant Category Codes (MCCs) and assigned Business Application Identifiers (BAIs) (VISA) or Transaction Type Indicators (TTIs) (Mastercard) are able to process a debit; namely exactly those that will result in the debit being a Visa Account Funding Transaction (AFT) or Mastercard Funding Transaction (FT).
 {{% /notice %}}

--- a/website/content/gateway/api_reference/resources/debits/debits.md
+++ b/website/content/gateway/api_reference/resources/debits/debits.md
@@ -14,5 +14,5 @@ Debits support the same parameters and payment methods as [Authorizations](#auth
 Information about sender and recipient is required for debits under certain circumstances to be compliant with card scheme rules. See [Sender information](#sender_information) and [Recipient information](#recipient_information).
 
 {{% notice %}}
-**Notice:** Only merchants with selected Merchant Category Codes (MCCs) and assigned Business Application Identifiers (BAIs) (VISA) or Transaction Type Indicator (TTI) (Mastercard) are able to process a debit; namely exactly those that will result in the debit being a Visa or Mastercard Account Funding Transaction (AFT).
+**Notice:** Only merchants with selected Merchant Category Codes (MCCs) and assigned Business Application Identifiers (BAIs) (VISA) or Transaction Type Indicators (TTIs) (Mastercard) are able to process a debit; namely exactly those that will result in the debit being a Visa or Mastercard Account Funding Transaction (AFT).
 {{% /notice %}}

--- a/website/content/gateway/api_reference/resources/debits/debits.md
+++ b/website/content/gateway/api_reference/resources/debits/debits.md
@@ -14,5 +14,5 @@ Debits support the same parameters and payment methods as [Authorizations](#auth
 Information about sender and recipient is required for debits under certain circumstances to be compliant with card scheme rules. See [Sender information](#sender_information) and [Recipient information](#recipient_information).
 
 {{% notice %}}
-**Notice:** Only merchants with selected Merchant Category Codes (MCCs) and assigned Business Application Identifiers (BAIs) (VISA) or Transaction Type Indicators (TTIs) (Mastercard) are able to process a debit; namely exactly those that will result in the debit being a Visa Account Funding Transaction (AFT) or Mastercard Funding Transaction (FT).
+**Notice:** Only merchants with selected Merchant Category Codes (MCCs) and assigned Business Application Identifiers (BAIs) (Visa) or Transaction Type Indicators (TTIs) (Mastercard) are able to process a debit; namely exactly those that will result in the debit being a Visa Account Funding Transaction (AFT) or Mastercard Funding Transaction (FT).
 {{% /notice %}}

--- a/website/content/gateway/api_reference/resources/debits/recipient_information.md
+++ b/website/content/gateway/api_reference/resources/debits/recipient_information.md
@@ -23,6 +23,11 @@ Example: "Doe Jane A." (last name, first name, optional middle initial).
 {{% regex_optional %}}Required.{{% /regex_optional %}}
 {{% /description_details %}}
 
+{{% description_term %}}recipient[account_type] {{% regex %}}(other|rtn_and_ban|iban|pan|email|phone_number|ban_and_bic|wallet_id|social_network_id){{% /regex %}}{{% /description_term %}}
+{{% description_details %}}The recipient's account type, i.e. the type of the account.
+{{% regex_optional %}}Required	for Mastercard; otherwise optional{{% /regex_optional %}}
+{{% /description_details %}}
+
 {{% description_term %}}recipient[reference] {{% regex %}}[\x20-\x7E]{1,16} [ASCII printable characters](https://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters){{% /regex %}}{{% /description_term %}}
 {{% description_details %}}Recipient reference number. You must be able to uniquely identify the recipient using this number.
 {{% regex_optional %}}Required if the merchant account's Business Application Identifier (BAI) is Funds Disbursement (FD).{{% /regex_optional %}}

--- a/website/content/gateway/api_reference/resources/debits/recipient_information.md
+++ b/website/content/gateway/api_reference/resources/debits/recipient_information.md
@@ -19,11 +19,11 @@ Example: "Doe Jane A." (last name, first name, optional middle initial).
 {{% /description_details %}}
 
 {{% description_term %}}recipient[account_number] {{% regex %}}[\x20-\x7E]{1,34} [ASCII printable characters](https://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters){{% /regex %}}{{% /description_term %}}
-{{% description_details %}}The recipient's account number, i.e. an identification of the account being funded by the debit. It can be an IBAN, a proprietary wallet number, a PAN, etc.
+{{% description_details %}}The recipient's account number, i.e. an identification of the account being funded by the debit.
 {{% regex_optional %}}Required.{{% /regex_optional %}}
 {{% /description_details %}}
 
-{{% description_term %}}recipient[account_number_type] {{% regex %}}(other|rtn_and_ban|iban|pan|email|phone_number|ban_and_bic|wallet_id|social_network_id){{% /regex %}}{{% /description_term %}}
+{{% description_term %}}recipient[account_number_type] {{% regex %}}(other|rtn_and_ban|iban|email|phone_number|ban_and_bic|wallet_id|social_network_id){{% /regex %}}{{% /description_term %}}
 {{% description_details %}}The recipient's account number type.
 {{% regex_optional %}}Required	for Mastercard; otherwise optional{{% /regex_optional %}}
 {{% /description_details %}}

--- a/website/content/gateway/api_reference/resources/debits/recipient_information.md
+++ b/website/content/gateway/api_reference/resources/debits/recipient_information.md
@@ -30,7 +30,7 @@ Example: "Doe Jane A." (last name, first name, optional middle initial).
 
 {{% description_term %}}recipient[reference] {{% regex %}}[\x20-\x7E]{1,16} [ASCII printable characters](https://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters){{% /regex %}}{{% /description_term %}}
 {{% description_details %}}Recipient reference number. You must be able to uniquely identify the recipient using this number.
-{{% regex_optional %}}Required if the merchant account's Business Application Identifier (BAI) is Funds Disbursement (FD).{{% /regex_optional %}}
+{{% regex_optional %}}Required for Visa if the merchant account's Business Application Identifier (BAI) is Funds Disbursement (FD).{{% /regex_optional %}}
 {{% /description_details %}}
 
 {{% /description_list %}}

--- a/website/content/gateway/api_reference/resources/debits/recipient_information.md
+++ b/website/content/gateway/api_reference/resources/debits/recipient_information.md
@@ -23,7 +23,7 @@ Example: "Doe Jane A." (last name, first name, optional middle initial).
 {{% regex_optional %}}Required.{{% /regex_optional %}}
 {{% /description_details %}}
 
-{{% description_term %}}recipient[account_type] {{% regex %}}(other|rtn_and_ban|iban|pan|email|phone_number|ban_and_bic|wallet_id|social_network_id){{% /regex %}}{{% /description_term %}}
+{{% description_term %}}recipient[account_number_type] {{% regex %}}(other|rtn_and_ban|iban|pan|email|phone_number|ban_and_bic|wallet_id|social_network_id){{% /regex %}}{{% /description_term %}}
 {{% description_details %}}The recipient's account type, i.e. the type of the account.
 {{% regex_optional %}}Required	for Mastercard; otherwise optional{{% /regex_optional %}}
 {{% /description_details %}}

--- a/website/content/gateway/api_reference/resources/debits/recipient_information.md
+++ b/website/content/gateway/api_reference/resources/debits/recipient_information.md
@@ -24,7 +24,7 @@ Example: "Doe Jane A." (last name, first name, optional middle initial).
 {{% /description_details %}}
 
 {{% description_term %}}recipient[account_number_type] {{% regex %}}(other|rtn_and_ban|iban|pan|email|phone_number|ban_and_bic|wallet_id|social_network_id){{% /regex %}}{{% /description_term %}}
-{{% description_details %}}The recipient's account type, i.e. the type of the account.
+{{% description_details %}}The recipient's account number type.
 {{% regex_optional %}}Required	for Mastercard; otherwise optional{{% /regex_optional %}}
 {{% /description_details %}}
 


### PR DESCRIPTION
We are currently moving credits to the Mastercard MoneySend framework. As part
of this migration we are implementing debits for Mastercard. As part of this
some extra information is required.