### PR TITLE
Correct SCA notice for MobilePay Online

### DIFF
--- a/website/content/gateway/api_reference/resources/authorizations/authorizations_methods/mobilepayonline.md
+++ b/website/content/gateway/api_reference/resources/authorizations/authorizations_methods/mobilepayonline.md
@@ -47,5 +47,5 @@ See [Authentication: [3dsecure]](#authentication-3dsecure).
 {{% notice %}}
 **Notice**: Signing is required to use the `mobilepayonline` payment method.
 
-**Notice**: An authorization made with `mobilepayonline` is strongly authenticated (SCA in PSD2). 
+**Notice**: An authorization made with `mobilepayonline` with a payment token is strongly authenticated (SCA in PSD2). 
 {{% /notice %}}


### PR DESCRIPTION
For the `mobilepayonline` payment method.

An authorization made with `mobilepayonline` without a payment token no longer provides SCA.