### PR TITLE
Change to name related parameters

### DIFF
--- a/website/content/gateway/api_reference/changes/changes.md
+++ b/website/content/gateway/api_reference/changes/changes.md
@@ -10,6 +10,15 @@ Follow coming changes on the [source code repository](https://github.com/clearha
 
 Sorted by descending timestamp.
 
+#### Change to name related parameters
+Starting XXXX-XX-XX, we will support new name related parameters 
+`recipient[first_name]`, `recipient[middle_name]`, `recipient[last_name]`,
+`sender[first_name]`, `sender[middle_name]` and `sender[last_name]`. This will
+in time push for the deprecation of `card[name]`, `recipient[name]` and 
+`sender[name]`. We will in a grace period allow for both old and new parameters,
+but we recommend that you plan the shift as we can't guarantee how long our 
+upstream provider supports the old fields.
+
 #### Add minimum amount for Visa captures and refunds
 Starting 2025-05-19, we will enforce a minimum amount of USD 0.005 for captures
 and refunds made with Visa. This is due to USD 0.005 being half a minor, and

--- a/website/content/gateway/api_reference/resources/credits/credits.md
+++ b/website/content/gateway/api_reference/resources/credits/credits.md
@@ -9,6 +9,9 @@ To payout (e.g. winnings and not refunds) money to a cardholder’s bank account
 ```shell
 POST https://gateway.clearhaus.com/credits
 ```
+
+Information about the recipient is required for credits to be compliant with card scheme rules. See [Recipient information](#credit_recipient_information).
+
 ##### Parameters
 {{% description_list %}}
 {{% description_term %}}amount{{% regex %}}[1-9][0-9]{,8}{{% /regex %}}{{% /description_term %}}
@@ -47,11 +50,6 @@ POST https://gateway.clearhaus.com/credits
 {{% description_term %}}card[csc] {{% regex %}} [0-9]{3}{{% /regex %}}{{% /description_term %}}
 {{% description_details %}}Card Security Code.
 {{% regex_optional %}}Optional.{{% /regex_optional %}}
-{{% /description_details %}}
-
-{{% description_term %}}card[name] {{% regex %}}[A-Za-z0-9 ]{1,30}{{% /regex %}}{{% /description_term %}}
-{{% description_details %}}Name on card.
-{{% regex_optional %}}Required for Mastercard Payment of Winnings (PoW) and for Mastercard cross-border non-PoW.{{% /regex_optional %}}
 {{% /description_details %}}
 
 {{% /description_list %}}

--- a/website/content/gateway/api_reference/resources/credits/recipient_information.md
+++ b/website/content/gateway/api_reference/resources/credits/recipient_information.md
@@ -1,0 +1,31 @@
+---
+title: "recipient_information"
+date: 2023-07-20T13:01:49+01:00
+anchor: "credit_recipient_information"
+weight: 181
+---
+##### Recipient information
+See the partner guideline for more details.
+
+{{% description_list %}}
+
+{{% description_term %}}recipient[first_name] {{% regex %}}[\x20-\x7E]{1,35} [ASCII printable characters](https://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters){{% /regex %}}{{% /description_term %}}
+{{% description_details %}}The recipient's legal first name.
+
+{{% regex_optional %}}It must not contain special characters (?, @, #, $, &, \*, etc.), be all numeric, be fictious, be a nickname or be incomplete.{{% /regex_optional %}}
+{{% regex_optional %}}Required for Mastercard Payment of Winnings (PoW) and for Mastercard cross-border non-PoW.{{% /regex_optional %}}
+{{% /description_details %}}
+
+{{% description_term %}}recipient[middle_name] {{% regex %}}[\x20-\x7E]{1,35} [ASCII printable characters](https://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters){{% /regex %}}{{% /description_term %}}
+{{% description_details %}}The recipient's legal middle name in case of any.
+{{% regex_optional %}}It must not contain special characters (?, @, #, $, &, \*, etc.), be all numeric, be fictious, be a nickname or be incomplete.{{% /regex_optional %}}
+{{% /description_details %}}
+
+{{% description_term %}}recipient[last_name] {{% regex %}}[\x20-\x7E]{1,35} [ASCII printable characters](https://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters){{% /regex %}}{{% /description_term %}}
+{{% description_details %}}The recipient's legal last name.
+
+{{% regex_optional %}}It must not contain special characters (?, @, #, $, &, \*, etc.), be all numeric, be fictious, be a nickname or be incomplete.{{% /regex_optional %}}
+{{% regex_optional %}}Required for Mastercard Payment of Winnings (PoW) and for Mastercard cross-border non-PoW.{{% /regex_optional %}}
+{{% /description_details %}}
+
+{{% /description_list %}}

--- a/website/content/gateway/api_reference/resources/debits/debits.md
+++ b/website/content/gateway/api_reference/resources/debits/debits.md
@@ -11,7 +11,7 @@ POST https://gateway.clearhaus.com/debits
 ```
 Debits support the same parameters and payment methods as [Authorizations](#authorizations), with the exception that amount must be greater than zero.
 
-Information about sender and recipient is required for debits under certain circumstances to be compliant with card scheme rules. See [Sender information](#sender_information) and [Recipient information](#recipient_information).
+Information about sender and recipient is required for debits under certain circumstances to be compliant with card scheme rules. See [Sender information](#sender_information) and [Recipient information](#debit_recipient_information).
 
 {{% notice %}}
 **Notice:** Only merchants with selected Merchant Category Codes (MCCs) and assigned Business Application Identifiers (BAIs) (Visa) or Transaction Type Indicators (TTIs) (Mastercard) are able to process a debit; namely exactly those that will result in the debit being a Visa Account Funding Transaction (AFT) or Mastercard Funding Transaction (FT).

--- a/website/content/gateway/api_reference/resources/debits/recipient_information.md
+++ b/website/content/gateway/api_reference/resources/debits/recipient_information.md
@@ -1,7 +1,7 @@
 ---
 title: "recipient_information"
 date: 2023-07-20T13:01:49+01:00
-anchor: "recipient_information"
+anchor: "debit_recipient_information"
 weight: 178
 ---
 ##### Recipient information
@@ -9,12 +9,22 @@ See the partner guideline for more details.
 
 {{% description_list %}}
 
-{{% description_term %}}recipient[name] {{% regex %}}[\x20-\x7E]{2,30} [ASCII printable characters](https://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters){{% /regex %}}{{% /description_term %}}
-{{% description_details %}}The recipient's legal name.
+{{% description_term %}}recipient[first_name] {{% regex %}}[\x20-\x7E]{1,35} [ASCII printable characters](https://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters){{% /regex %}}{{% /description_term %}}
+{{% description_details %}}The recipient's legal first name.
 
-Example: "Doe Jane A." (last name, first name, optional middle initial).
+{{% regex_optional %}}It must not contain special characters (?, @, #, $, &, \*, etc.), be all numeric, be fictious, be a nickname or be incomplete.{{% /regex_optional %}}
+{{% regex_optional %}}Required.{{% /regex_optional %}}
+{{% /description_details %}}
 
-{{% regex_optional %}}It must not contain special characters (?, @, #, $, &, \*, etc.), be all numeric, be fictious, be a nickname or be incomplete (only first or last name).{{% /regex_optional %}}
+{{% description_term %}}recipient[middle_name] {{% regex %}}[\x20-\x7E]{1,35} [ASCII printable characters](https://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters){{% /regex %}}{{% /description_term %}}
+{{% description_details %}}The recipient's legal middle name in case of any.
+{{% regex_optional %}}It must not contain special characters (?, @, #, $, &, \*, etc.), be all numeric, be fictious, be a nickname or be incomplete.{{% /regex_optional %}}
+{{% /description_details %}}
+
+{{% description_term %}}recipient[last_name] {{% regex %}}[\x20-\x7E]{1,35} [ASCII printable characters](https://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters){{% /regex %}}{{% /description_term %}}
+{{% description_details %}}The recipient's legal last name.
+
+{{% regex_optional %}}It must not contain special characters (?, @, #, $, &, \*, etc.), be all numeric, be fictious, be a nickname or be incomplete.{{% /regex_optional %}}
 {{% regex_optional %}}Required.{{% /regex_optional %}}
 {{% /description_details %}}
 

--- a/website/content/gateway/api_reference/resources/debits/sender_information.md
+++ b/website/content/gateway/api_reference/resources/debits/sender_information.md
@@ -11,12 +11,23 @@ Intra-EEA, mentioned below, includes the United Kingdom and Gibraltar.
 
 {{% description_list %}}
 
-{{% description_term %}}sender[name] {{% regex %}}[\x20-\x7E]{2,30} [ASCII printable characters](https://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters){{% /regex %}}{{% /description_term %}}
-{{% description_details %}}The sender's legal name.
+{{% description_term %}}sender[first_name] {{% regex %}}[\x20-\x7E]{1,35} [ASCII printable characters](https://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters){{% /regex %}}{{% /description_term %}}
+{{% description_details %}}The sender's legal first name.
 
-Example: "Doe Jane A." (last name, first name, optional middle initial).
+{{% regex_optional %}}It must not contain special characters (?, @, #, $, &, \*, etc.), be all numeric, be fictious, be a nickname or be incomplete.{{% /regex_optional %}}
+{{% regex_optional %}}Required for intra-EEA and international debits. Also required if any of the address-related parameters are supplied.{{% /regex_optional %}}
+{{% /description_details %}}
 
-{{% regex_optional %}}It must not contain special characters (?, @, #, $, &, \*, etc.), be all numeric, be fictious, be a nickname or be incomplete (only first or last name).{{% /regex_optional %}}
+{{% description_term %}}sender[middle_name] {{% regex %}}[\x20-\x7E]{1,35} [ASCII printable characters](https://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters){{% /regex %}}{{% /description_term %}}
+{{% description_details %}}The sender's legal middle name in case of any.
+
+{{% regex_optional %}}It must not contain special characters (?, @, #, $, &, \*, etc.), be all numeric, be fictious, be a nickname or be incomplete.{{% /regex_optional %}}
+{{% /description_details %}}
+
+{{% description_term %}}sender[last_name] {{% regex %}}[\x20-\x7E]{1,35} [ASCII printable characters](https://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters){{% /regex %}}{{% /description_term %}}
+{{% description_details %}}The sender's legal last name.
+
+{{% regex_optional %}}It must not contain special characters (?, @, #, $, &, \*, etc.), be all numeric, be fictious, be a nickname or be incomplete.{{% /regex_optional %}}
 {{% regex_optional %}}Required for intra-EEA and international debits. Also required if any of the address-related parameters are supplied.{{% /regex_optional %}}
 {{% /description_details %}}
 

--- a/website/content/gateway/examples/payout_to_cardholder/payout_to_cardholder.md
+++ b/website/content/gateway/examples/payout_to_cardholder/payout_to_cardholder.md
@@ -33,5 +33,5 @@ Example response (snippet):
 }
 ```
 
-The field {{% highlight_text %}}card[name]{{% /highlight_text %}} is mandatory for Mastercard Payment of winnings (gaming/gambling merchants).
+The field {{% highlight_text %}}recipient[first_name]{{% /highlight_text %}} and {{% highlight_text %}}recipient[last_name]{{% /highlight_text %}} is mandatory for Mastercard Payment of winnings (gaming/gambling merchants).
 Depending on card scheme and merchant category, the name on the card might be necessary for approval of credits.


### PR DESCRIPTION
New name related parameters will be added:
- `recipient[first_name]`
- `recipient[middle_name]`
- `recipient[last_name]`
- `sender[first_name]`
- `sender[middle_name]`
- `sender[last_name]`

This will in time push for the deprecation of:
- `card[name]`
- `recipient[name]`
- `sender[name]`

We will in a grace period allow for both old and new parameters, but we recommend that you plan the shift as we can't guarantee how long our upstream provider supports the old fields.