### PR TITLE
Add raw values for 3dsecure

### DIFF
--- a/website/content/gateway/api_reference/changes/changes.md
+++ b/website/content/gateway/api_reference/changes/changes.md
@@ -10,6 +10,11 @@ Follow coming changes on the [source code repository](https://github.com/clearha
 
 Sorted by descending timestamp.
 
+#### Addition of raw 3-D Secure version 2 authentication data
+Starting 2026-07-27, raw 3-D Secure version 2 authentication data can be
+supplied using `[3dsecure][v2][raw]` as an alternative to `[3dsecure][v2][ares]` and `[3dsecure][v2][rreq]`.
+See [Authentication: [3dsecure][v2]](#authentication-3dsecure-v2) for details.
+
 #### Additional SCA exemtions added
 Starting 2025-12-12, we will start accepting new parameters for `sca_exemption`.
 The two new parameters are `low_value_payment` and `secure_corporate_payment`

--- a/website/content/gateway/api_resources/authorizations/authentications/3dsecure_v2.md
+++ b/website/content/gateway/api_resources/authorizations/authentications/3dsecure_v2.md
@@ -5,31 +5,39 @@ anchor: "authentication-3dsecure-v2"
 weight: 255
 ---
 ### Authentication: [3dsecure][v2]
+
 Three 3-D Secure authentication methods are available: `ares`, `rreq` and `raw`. Only one may be present.
 
 #### Authentication: ARes
+
 {{% description_list %}}
 {{% description_term %}}[3dsecure][v2][ares] {{% regex %}}[\:json\:]{{% /regex %}}{{% /description_term %}}
 {{% description_details %}}The 3-D Secure version 2 ARes containing authenticationValue, dsTransID, etc.{{% /description_details %}}
+{{% /description_list %}}
 
 #### Authentication: RReq
+
+{{% description_list %}}
 {{% description_term %}}[3dsecure][v2][rreq] {{% regex %}}[\:json\:]{{% /regex %}}{{% /description_term %}}
 {{% description_details %}}The 3-D Secure version 2 RReq containing authenticationValue, dsTransID, etc.{{% /description_details %}}
+{{% /description_list %}}
 
 #### Authentication: Raw
+
+{{% description_list %}}
 {{% description_term %}}[3dsecure][v2][raw][eci] {{% regex %}}[0-9]{2}{{% /regex %}}{{% /description_term %}}
 {{% description_details %}}The 3-D Secure version 2 ECI.
-{{% regex_optional %}}Optional. Required for Visa.{{% /regex_optional %}}{{% /description_details %}}
+{{% regex_optional %}}Required for Visa. Required for Mastercard when `trans_status` is `Y`, `A`, `I` or `U`.{{% /regex_optional %}}{{% /description_details %}}
 
 {{% description_term %}}[3dsecure][v2][raw][av] {{% regex %}}[:base64:]{28}{{% /regex %}}{{% /description_term %}}
 {{% description_details %}}The 3-D Secure version 2 authentication value.
-{{% regex_optional %}}Optional.{{% /regex_optional %}}{{% /description_details %}}
+{{% regex_optional %}}Required for Visa. Required for Mastercard when `trans_status` is `Y`, `A`, `I` or `U`.{{% /regex_optional %}}{{% /description_details %}}
 
 {{% description_term %}}[3dsecure][v2][raw][trans_status] {{% regex %}}[A-Z]{{% /regex %}}{{% /description_term %}}
 {{% description_details %}}The 3-D Secure version 2 trans status.
 {{% /description_details %}}
 
-{{% description_term %}}[3dsecure][v2][raw][message_version] {{% regex %}}[0-9].[0-9].[0-9]{{% /regex %}}{{% /description_term %}}
+{{% description_term %}}[3dsecure][v2][raw][message_version] {{% regex %}}[0-9]\.[0-9]\.[0-9]{{% /regex %}}{{% /description_term %}}
 {{% description_details %}}The 3-D Secure version 2 message version.
 {{% /description_details %}}
 
@@ -41,8 +49,8 @@ Three 3-D Secure authentication methods are available: `ares`, `rreq` and `raw`.
 {{% description_details %}}The 3-D Secure version 2 authentication type.
 {{% regex_optional %}}Optional.{{% /regex_optional %}}{{% /description_details %}}
 
-{{% description_term %}}[3dsecure][v2][raw][ds_trans_id] {{% regex %}}[\:UUID\:]{{% /regex %}}{{% /description_term %}}
-{{% description_details %}}The 3-D Secure version 2 ds transaction id.
-{{% regex_optional %}}Optional. Required for Mastercard. {{% /regex_optional %}}{{% /description_details %}}
+{{% description_term %}}[3dsecure][v2][raw][ds_trans_id] {{% regex %}}[\:UUIDv4\:]{{% /regex %}}{{% /description_term %}}
+{{% description_details %}}The 3-D Secure version 2 DS transaction ID.
+{{% regex_optional %}}Required for Mastercard.{{% /regex_optional %}}{{% /description_details %}}
 
 {{% /description_list %}}

--- a/website/content/gateway/api_resources/authorizations/authentications/3dsecure_v2.md
+++ b/website/content/gateway/api_resources/authorizations/authentications/3dsecure_v2.md
@@ -37,7 +37,7 @@ Three 3-D Secure authentication methods are available: `ares`, `rreq` and `raw`.
 {{% description_details %}}The 3-D Secure version 2 trans status.
 {{% /description_details %}}
 
-{{% description_term %}}[3dsecure][v2][raw][message_version] {{% regex %}}[0-9]\.[0-9]\.[0-9]{{% /regex %}}{{% /description_term %}}
+{{% description_term %}}[3dsecure][v2][raw][message_version] {{% regex %}}2[.][0-9][.][0-9]{{% /regex %}}{{% /description_term %}}
 {{% description_details %}}The 3-D Secure version 2 message version.
 {{% /description_details %}}
 

--- a/website/content/gateway/api_resources/authorizations/authentications/3dsecure_v2.md
+++ b/website/content/gateway/api_resources/authorizations/authentications/3dsecure_v2.md
@@ -5,22 +5,44 @@ anchor: "authentication-3dsecure-v2"
 weight: 255
 ---
 ### Authentication: [3dsecure][v2]
+Three 3-D Secure authentication methods are available: `ares`, `rreq` and `raw`. Only one may be present.
 
+#### Authentication: ARes
 {{% description_list %}}
 {{% description_term %}}[3dsecure][v2][ares] {{% regex %}}[\:json\:]{{% /regex %}}{{% /description_term %}}
-{{% description_details %}}The 3-D Secure version 2 ARes containing authenticationValue, dsTransID, etc.
-{{% regex_optional %}}Optional. Cannot be present if `rreq` or `raw` is present.{{% /regex_optional %}}{{% /description_details %}}
+{{% description_details %}}The 3-D Secure version 2 ARes containing authenticationValue, dsTransID, etc.{{% /description_details %}}
 
+#### Authentication: RReq
 {{% description_term %}}[3dsecure][v2][rreq] {{% regex %}}[\:json\:]{{% /regex %}}{{% /description_term %}}
-{{% description_details %}}The 3-D Secure version 2 RReq containing authenticationValue, dsTransID, etc.
-{{% regex_optional %}}Optional. Cannot be present if `ares` or `raw` is present.{{% /regex_optional %}}{{% /description_details %}}
+{{% description_details %}}The 3-D Secure version 2 RReq containing authenticationValue, dsTransID, etc.{{% /description_details %}}
 
-{{% description_term %}}[3dsecure][v2][raw][eci] {{% regex %}}[\:json\:]{{% /regex %}}{{% /description_term %}}
+#### Authentication: Raw
+{{% description_term %}}[3dsecure][v2][raw][eci] {{% regex %}}[0-9]{2}{{% /regex %}}{{% /description_term %}}
 {{% description_details %}}The 3-D Secure version 2 ECI.
-{{% regex_optional %}}Optional. Cannot be present if `rreq` or `ares` is present. Required if `raw[av]` is present.{{% /regex_optional %}}{{% /description_details %}}
+{{% regex_optional %}}Optional. Required for Visa.{{% /regex_optional %}}{{% /description_details %}}
 
-{{% description_term %}}[3dsecure][v2][raw][av] {{% regex %}}[\:json\:]{{% /regex %}}{{% /description_term %}}
+{{% description_term %}}[3dsecure][v2][raw][av] {{% regex %}}[:base64:]{28}{{% /regex %}}{{% /description_term %}}
 {{% description_details %}}The 3-D Secure version 2 authentication value.
-{{% regex_optional %}}Optional. Cannot be present if `rreq` or `ares` is present. Required if `raw[eci]` is present.{{% /regex_optional %}}{{% /description_details %}}
+{{% regex_optional %}}Optional.{{% /regex_optional %}}{{% /description_details %}}
+
+{{% description_term %}}[3dsecure][v2][raw][trans_status] {{% regex %}}[A-Z]{{% /regex %}}{{% /description_term %}}
+{{% description_details %}}The 3-D Secure version 2 trans status.
+{{% /description_details %}}
+
+{{% description_term %}}[3dsecure][v2][raw][message_version] {{% regex %}}[0-9].[0-9].[0-9]{{% /regex %}}{{% /description_term %}}
+{{% description_details %}}The 3-D Secure version 2 message version.
+{{% /description_details %}}
+
+{{% description_term %}}[3dsecure][v2][raw][message_type] {{% regex %}}(ARes|RReq){{% /regex %}}{{% /description_term %}}
+{{% description_details %}}The 3-D Secure version 2 message type.
+{{% /description_details %}}
+
+{{% description_term %}}[3dsecure][v2][raw][authentication_type] {{% regex %}}[0-9]{2}{{% /regex %}}{{% /description_term %}}
+{{% description_details %}}The 3-D Secure version 2 authentication type.
+{{% regex_optional %}}Optional.{{% /regex_optional %}}{{% /description_details %}}
+
+{{% description_term %}}[3dsecure][v2][raw][ds_trans_id] {{% regex %}}[\:UUID\:]{{% /regex %}}{{% /description_term %}}
+{{% description_details %}}The 3-D Secure version 2 ds transaction id.
+{{% regex_optional %}}Optional. Required for Mastercard. {{% /regex_optional %}}{{% /description_details %}}
 
 {{% /description_list %}}

--- a/website/content/gateway/api_resources/authorizations/authentications/3dsecure_v2.md
+++ b/website/content/gateway/api_resources/authorizations/authentications/3dsecure_v2.md
@@ -9,10 +9,18 @@ weight: 255
 {{% description_list %}}
 {{% description_term %}}[3dsecure][v2][ares] {{% regex %}}[\:json\:]{{% /regex %}}{{% /description_term %}}
 {{% description_details %}}The 3-D Secure version 2 ARes containing authenticationValue, dsTransID, etc.
-{{% regex_optional %}}Optional. Cannot be present if `rreq` is present.{{% /regex_optional %}}{{% /description_details %}}
+{{% regex_optional %}}Optional. Cannot be present if `rreq` or `raw` is present.{{% /regex_optional %}}{{% /description_details %}}
 
 {{% description_term %}}[3dsecure][v2][rreq] {{% regex %}}[\:json\:]{{% /regex %}}{{% /description_term %}}
 {{% description_details %}}The 3-D Secure version 2 RReq containing authenticationValue, dsTransID, etc.
-{{% regex_optional %}}Optional. Cannot be present if `ares` is present.{{% /regex_optional %}}{{% /description_details %}}
+{{% regex_optional %}}Optional. Cannot be present if `ares` or `raw` is present.{{% /regex_optional %}}{{% /description_details %}}
+
+{{% description_term %}}[3dsecure][v2][raw][eci] {{% regex %}}[\:json\:]{{% /regex %}}{{% /description_term %}}
+{{% description_details %}}The 3-D Secure version 2 ECI.
+{{% regex_optional %}}Optional. Cannot be present if `rreq` or `ares` is present. Required if `raw[av]` is present.{{% /regex_optional %}}{{% /description_details %}}
+
+{{% description_term %}}[3dsecure][v2][raw][av] {{% regex %}}[\:json\:]{{% /regex %}}{{% /description_term %}}
+{{% description_details %}}The 3-D Secure version 2 authentication value.
+{{% regex_optional %}}Optional. Cannot be present if `rreq` or `ares` is present. Required if `raw[eci]` is present.{{% /regex_optional %}}{{% /description_details %}}
 
 {{% /description_list %}}

--- a/website/content/gateway/api_resources/authorizations/authentications/3dsecure_v2.md
+++ b/website/content/gateway/api_resources/authorizations/authentications/3dsecure_v2.md
@@ -26,31 +26,31 @@ Three 3-D Secure authentication methods are available: `ares`, `rreq` and `raw`.
 
 {{% description_list %}}
 {{% description_term %}}[3dsecure][v2][raw][eci] {{% regex %}}[0-9]{2}{{% /regex %}}{{% /description_term %}}
-{{% description_details %}}The 3-D Secure version 2 ECI.
+{{% description_details %}}The 3-D Secure version 2 `eci`.
 {{% regex_optional %}}Required for Visa. Required for Mastercard when `trans_status` is `Y`, `A`, `I` or `U`.{{% /regex_optional %}}{{% /description_details %}}
 
 {{% description_term %}}[3dsecure][v2][raw][av] {{% regex %}}[:base64:]{28}{{% /regex %}}{{% /description_term %}}
-{{% description_details %}}The 3-D Secure version 2 authentication value.
+{{% description_details %}}The 3-D Secure version 2 `authenticationValue`.
 {{% regex_optional %}}Required for Visa. Required for Mastercard when `trans_status` is `Y`, `A`, `I` or `U`.{{% /regex_optional %}}{{% /description_details %}}
 
 {{% description_term %}}[3dsecure][v2][raw][trans_status] {{% regex %}}[A-Z]{{% /regex %}}{{% /description_term %}}
-{{% description_details %}}The 3-D Secure version 2 trans status.
+{{% description_details %}}The 3-D Secure version 2 `transStatus`.
 {{% /description_details %}}
 
 {{% description_term %}}[3dsecure][v2][raw][message_version] {{% regex %}}2[.][0-9][.][0-9]{{% /regex %}}{{% /description_term %}}
-{{% description_details %}}The 3-D Secure version 2 message version.
+{{% description_details %}}The 3-D Secure version 2 `messageVersion`.
 {{% /description_details %}}
 
 {{% description_term %}}[3dsecure][v2][raw][message_type] {{% regex %}}(ARes|RReq){{% /regex %}}{{% /description_term %}}
-{{% description_details %}}The 3-D Secure version 2 message type.
+{{% description_details %}}The 3-D Secure version 2 `messageType`.
 {{% /description_details %}}
 
 {{% description_term %}}[3dsecure][v2][raw][authentication_type] {{% regex %}}[0-9]{2}{{% /regex %}}{{% /description_term %}}
-{{% description_details %}}The 3-D Secure version 2 authentication type.
+{{% description_details %}}The 3-D Secure version 2 `authenticationType`.
 {{% regex_optional %}}Optional.{{% /regex_optional %}}{{% /description_details %}}
 
 {{% description_term %}}[3dsecure][v2][raw][ds_trans_id] {{% regex %}}[\:UUIDv4\:]{{% /regex %}}{{% /description_term %}}
-{{% description_details %}}The 3-D Secure version 2 DS transaction ID.
+{{% description_details %}}The 3-D Secure version 2 `dsTransID`.
 {{% regex_optional %}}Required for Mastercard.{{% /regex_optional %}}{{% /description_details %}}
 
 {{% /description_list %}}


### PR DESCRIPTION
See https://github.com/clearhaus/gateway-api-docs/pull/241#issuecomment-4966203968 for newest version of documentation

Allow sending raw 3dsecure values:

<img width="682" height="656" alt="image" src="https://github.com/user-attachments/assets/49197953-9ecf-4eed-976a-6258fa007b17" />
