### PR TITLE
Add 42900 status code to docs

### DIFF
--- a/website/content/gateway/api_reference/transaction_status/transaction_status_codes_table.md
+++ b/website/content/gateway/api_reference/transaction_status/transaction_status_codes_table.md
@@ -27,6 +27,7 @@ weight: 315
 | 40415 | Amount limit exceeded              | ✓    |         | ✓      |      | ✓      | ✓      | ✓            |
 | 40416 | Additional authentication required | ✓    |         | ✓      |      | ✓      | ✓      | ✓            |
 | 40420 | Merchant blocked by cardholder     | ✓    |         | ✓      |      | ✓      | ✓      | ✓            |
+| 42900 | Clearhaus retry limit exceeded     | ✓    |         |        |      |        |        |              |
 | 50000 | Clearhaus error                    | ✓    | ✓       | ✓      | ✓    | ✓      | ✓      | ✓            |
 
 Status code `20000` is the only code for which the transaction is approved. For the other codes the transaction is declined.


### PR DESCRIPTION
As part of introducing new retry fields in the response we are also introducing a new response code to indicate when no more remaining retries are left.