### PR TITLE
Remove perl from docker image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,6 +3,9 @@ FROM node:22-trixie-slim
 # Install Hugo
 RUN apt-get update && \
     apt-get install -y hugo && \
+    # perl-base is Essential, hence --allow-remove-essential; nothing in this
+    # image needs perl at runtime.
+    apt-get purge -y --allow-remove-essential perl-base && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,7 +3,7 @@ FROM node:22-trixie-slim
 # Install Hugo
 RUN apt-get update && \
     apt-get install -y hugo && \
-    # perl-base is Essential, hence --allow-remove-essential; nothing in this
+    # perl-base is essential, hence --allow-remove-essential; nothing in this
     # image needs perl at runtime.
     apt-get purge -y --allow-remove-essential perl-base && \
     apt-get clean && \


### PR DESCRIPTION
I've removed perl since there was a lot of new vulnerabilities found in it. We don't need it, and the service runs without it.